### PR TITLE
Remove naive check for SQL SELECT query

### DIFF
--- a/src/cbioportal_mcp/server.py
+++ b/src/cbioportal_mcp/server.py
@@ -131,8 +131,6 @@ def run_select_query(query: str) -> list[dict]:
         list: A list of rows, where each row is a dictionary with column names as keys and corresponding values.
     """
     from mcp_clickhouse.mcp_server import run_select_query
-    if not query.strip().upper().startswith("SELECT"):
-        raise ValueError(f"Non select queries are forbidden: '{query}'. Skipping the query.")
     logger.debug("run_select_query: delegate the query to run_select_query tool of ClickHouse MCP")
     ch_query_result = run_select_query(query)
     result = zip_select_query_result(ch_query_result)


### PR DESCRIPTION
There are select queries that start with WITH statement (CTE) and many more.
We have to limit the db user to select queries on the database and the system database (to explore tables and their columns) instead.