### PR TITLE
Update README FastMCP dev command for newer FastMCP versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ export CLICKHOUSE_MCP_SERVER_TRANSPORT=stdio # or http or sse
 To connect to the MCP server and see requests and replies, use MCP Inspector.
 You can run it with:
 ```bash
-fastmcp dev src/cbioportal_mcp/server.py
+fastmcp dev inspector src/cbioportal_mcp/server.py
 ```
 
 ### Running the Server


### PR DESCRIPTION
Updates the README command for launching the MCP Inspector with current FastMCP CLI syntax.

The previous command matches older FastMCP versions, but newer releases require `fastmcp dev inspector ...`. Since `fastmcp` is not pinned to an older version in `pyproject.toml`, the existing README example can fail in fresh environments.