### PR TITLE
Report mutation frequencies as percentages, not raw counts

### DIFF
--- a/src/cbioportal_mcp/resources/mutation-frequency-guide.md
+++ b/src/cbioportal_mcp/resources/mutation-frequency-guide.md
@@ -1,5 +1,12 @@
 # Mutation Frequency Analysis Guide
 
+## IMPORTANT: Reporting Mutation Frequencies
+- **ALWAYS report frequencies as percentages**, not raw counts: `frequency = (altered_samples / total_profiled_samples) × 100`
+- For quick frequency lookups, **prefer the TCGA Pan-Cancer Atlas study first**, then offer to expand to other studies
+- When reporting across multiple studies, show **ranges** (e.g., "TP53 is mutated in 30–60% of samples") rather than a single average
+- **NEVER** sum mutation events across studies to compute an aggregate frequency — this can exceed 100% due to double-counting
+- Warn users that samples may overlap across cohorts (e.g., MSK studies may share patients)
+
 ## Overview
 For accurate gene mutation frequency calculations, you must use gene-specific profiling denominators, not study-wide sample counts.
 

--- a/src/cbioportal_mcp/resources/system-prompt.md
+++ b/src/cbioportal_mcp/resources/system-prompt.md
@@ -69,4 +69,4 @@ For out-of-scope questions, respond: "This question is outside the scope of cBio
    - Use only tables and columns that exist in the schema
    - Follow the specific patterns from the MCP resources
 5. Return results in structured format (JSON) when appropriate.
-6. Be concise, use raw counts instead of percentages, and always verify column names with the guides before querying.
+6. When reporting mutation frequencies, ALWAYS show percentages (altered/profiled × 100), not just raw counts. For quick lookups, prefer TCGA Pan-Cancer Atlas studies first.

--- a/src/cbioportal_mcp/resources/system-prompt.md
+++ b/src/cbioportal_mcp/resources/system-prompt.md
@@ -69,4 +69,4 @@ For out-of-scope questions, respond: "This question is outside the scope of cBio
    - Use only tables and columns that exist in the schema
    - Follow the specific patterns from the MCP resources
 5. Return results in structured format (JSON) when appropriate.
-6. When reporting mutation frequencies, ALWAYS show percentages (altered/profiled × 100), not just raw counts. For quick lookups, prefer TCGA Pan-Cancer Atlas studies first.
+6. When reporting mutation frequencies, ALWAYS show percentages (altered/profiled × 100), not just raw counts. For quick lookups, prefer TCGA Pan-Cancer Atlas studies first. Be concise, and always verify column names with the guides before querying.


### PR DESCRIPTION
## Summary
- Fixes #23
- Updates system prompt rule to instruct bot to show percentages (altered/profiled × 100) instead of raw counts
- Adds IMPORTANT section to mutation-frequency-guide.md with 5 key rules:
  1. Always report percentages
  2. Prefer TCGA Pan-Cancer Atlas for quick lookups
  3. Show ranges across studies, not averages
  4. Never sum across studies (prevents >100% frequencies)
  5. Warn about overlapping cohorts (e.g. MSK studies)
- Preserves existing 'Be concise' and 'verify column names' guidance in rule 6

## Test plan
- [ ] Ask bot about mutation frequency of TP53 in lung cancer — should return percentages
- [ ] Ask about most mutated genes — should show frequencies, not just counts
- [ ] Ask about frequency across multiple studies — should show ranges, not averages