### PR TITLE
Pin mcp-clickhouse==0.1.11 (fix run_select_query import error)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,17 +4,16 @@ FROM python:3.11-slim
 # Set working directory
 WORKDIR /app
 
-# Install system dependencies
-RUN apt-get update && apt-get install -y \
+# uv (instead of pip) so the build respects uv.lock
+RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     curl \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && pip install --no-cache-dir uv
 
-# Copy the source code into the image
 COPY . /app
 
-# Install dependencies
-RUN pip install --upgrade pip && pip install .
+RUN uv sync --frozen --no-dev
 
 # Set environment variables expected at runtime (user should override as needed)
 ENV CLICKHOUSE_HOST=localhost \
@@ -31,5 +30,4 @@ ENV CLICKHOUSE_HOST=localhost \
 # Expose port (optional — based on what the MCP server binds to; change if needed)
 EXPOSE 8000
 
-# Default command
-CMD ["cbioportal-mcp"]
+CMD ["uv", "run", "cbioportal-mcp"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,11 +14,7 @@ authors = [
 ]
 dependencies = [
     "fastmcp",
-    # Pin mcp-clickhouse: 0.3.0 renamed the underlying tool from
-    # `run_select_query` to `run_query`, breaking our import at
-    # src/cbioportal_mcp/server.py. uv.lock already pins 0.1.11, but
-    # Dockerfile uses `pip install .` which ignores the lock and pulls
-    # PyPI latest. Pin explicitly here so fresh image builds match.
+    # 0.3.0 renamed run_select_query → run_query (breaking change)
     "mcp-clickhouse==0.1.11",
     "clickhouse-driver>=0.2.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,12 @@ authors = [
 ]
 dependencies = [
     "fastmcp",
-    "mcp-clickhouse",
+    # Pin mcp-clickhouse: 0.3.0 renamed the underlying tool from
+    # `run_select_query` to `run_query`, breaking our import at
+    # src/cbioportal_mcp/server.py. uv.lock already pins 0.1.11, but
+    # Dockerfile uses `pip install .` which ignores the lock and pulls
+    # PyPI latest. Pin explicitly here so fresh image builds match.
+    "mcp-clickhouse==0.1.11",
     "clickhouse-driver>=0.2.0",
 ]
 


### PR DESCRIPTION
## Problem

Fresh image builds were crashing with:

> cannot import name 'run_select_query' from 'mcp_clickhouse.mcp_server'

## Cause

`mcp-clickhouse` 0.3.0 (released after our last working build) renamed the underlying tool from `run_select_query` → `run_query`. Our code imports the old name:

```python
# src/cbioportal_mcp/server.py:363
from mcp_clickhouse.mcp_server import run_select_query
```

`uv.lock` already pinned `0.1.11`, but the Dockerfile used `pip install .` which **ignores the lock** and resolves to PyPI latest — so fresh builds pulled `0.3.0`.

## Fix

Two layers of defense:

1. **Pin `mcp-clickhouse==0.1.11` in `pyproject.toml`** — documents the constraint and protects any future build path that uses bare `pip install`.
2. **Switch the Dockerfile to `uv sync --frozen --no-dev`** — installs from `uv.lock` exactly, fails the build if `pyproject.toml` has drifted from the lock. Same versions in Docker as in local dev going forward.

## Test plan

- [ ] CI publishes fresh `cbioportal/mcp:latest`
- [ ] Roll the prod cbioagent-clickhouse-mcp deployment: `kubectl rollout restart deployment cbioagent-clickhouse-mcp`
- [ ] `kubectl logs deploy/cbioagent-clickhouse-mcp` clean, MCP responds to a sample query
- [ ] Spot-check: a future stray dependency bump in `pyproject.toml` without a corresponding `uv lock` should now fail the Docker build (instead of silently pulling something the code doesn't support)