### PR TITLE
Speed up CI: layered Dockerfile + native arm64 runners

### DIFF
--- a/.github/workflows/docker_ci.yml
+++ b/.github/workflows/docker_ci.yml
@@ -7,18 +7,29 @@ on:
   workflow_dispatch:
     inputs:
       ref:
-        description: 'Git ref to build and tag the image (branch, tag, or commit SHA)'
+        description: "Git ref to build and tag the image (branch, tag, or commit SHA)"
         type: string
         required: true
 
 jobs:
-  docker-build:
-    runs-on: ubuntu-latest
+  # Per-architecture build on a native runner. arm64 uses ubuntu-24.04-arm
+  # (free on public repos), avoiding the ~5-10x slowdown of QEMU emulation.
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref != '' && github.event.inputs.ref || github.ref }}
+
       - name: Set image tag
         id: set-tag
         run: |
@@ -27,7 +38,9 @@ jobs:
           else
             echo "IMAGE_TAG=latest" >> $GITHUB_ENV
           fi
-          echo "Using IMAGE_TAG=$IMAGE_TAG"
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+        env:
+          platform: ${{ matrix.platform }}
 
       - name: Log in to DockerHub
         uses: docker/login-action@v3
@@ -35,18 +48,68 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build and push multi-arch image
+      - name: Build and push (by digest)
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
           file: docker/Dockerfile
-          cache-from: type=gha
-          cache-to: type=gha
-          tags: cbioportal/mcp:${{ env.IMAGE_TAG }}
+          platforms: ${{ matrix.platform }}
+          # Push by digest only; the merge job tags the final manifest.
+          outputs: type=image,name=cbioportal/mcp,push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=${{ env.PLATFORM_PAIR }}
+          cache-to: type=gha,scope=${{ env.PLATFORM_PAIR }},mode=max
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set image tag
+        run: |
+          if [ -n "${{ github.event.inputs.ref }}" ]; then
+            echo "IMAGE_TAG=${{ github.event.inputs.ref }}" >> $GITHUB_ENV
+          else
+            echo "IMAGE_TAG=latest" >> $GITHUB_ENV
+          fi
+
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Log in to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Create multi-arch manifest
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create -t cbioportal/mcp:${{ env.IMAGE_TAG }} \
+            $(printf 'cbioportal/mcp@sha256:%s ' *)
+
+      - name: Inspect
+        run: docker buildx imagetools inspect cbioportal/mcp:${{ env.IMAGE_TAG }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,8 +11,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/* \
     && pip install --no-cache-dir uv
 
-COPY . /app
+# Deps-only layer — cache stays warm unless pyproject/uv.lock change.
+COPY pyproject.toml uv.lock README.md ./
+RUN uv sync --frozen --no-dev --no-install-project
 
+# Source layer — invalidates on any source/SQL change. The install below
+# is a fast project-only step now that deps are already in .venv.
+COPY . /app
 RUN uv sync --frozen --no-dev
 
 # Set environment variables expected at runtime (user should override as needed)


### PR DESCRIPTION
## Problem

CI builds take ~5-6 minutes even when only a SQL file changes. Two compounding causes:

1. **`COPY . /app` invalidates on any file change.** Every push forces `uv sync` to re-resolve and re-install all Python deps, even when only an unrelated file (SQL, README, k8s manifest) changed.
2. **arm64 builds run under QEMU emulation.** The workflow targets both `linux/amd64` and `linux/arm64` on a single amd64 GitHub runner. The arm64 half emulates every step (apt-install, uv-install, etc.) at ~5-10x slowdown.

## Fixes

### Dockerfile: deps-first layered cache

```dockerfile
# Deps layer — only invalidates when pyproject/uv.lock change
COPY pyproject.toml uv.lock README.md ./
RUN uv sync --frozen --no-dev --no-install-project

# Source layer — invalidates on any source/SQL change
COPY . /app
RUN uv sync --frozen --no-dev   # fast: deps already in .venv
```

### Workflow: matrix build with native arm64 runner

Splits the multi-arch build into two parallel jobs on native hardware (`ubuntu-latest` for amd64, `ubuntu-24.04-arm` for arm64 — free on public repos), then merges digests into a single multi-arch manifest. Per-platform GHA cache scopes prevent the two builds from clobbering each other.

## Expected impact

| change | before | after (warm cache) | after (cold cache) |
|---|---|---|---|
| SQL-only change | ~5-6 min | ~1-2 min | ~3-4 min |
| code change | ~5-6 min | ~2-3 min | ~3-4 min |
| dep change (pyproject/uv.lock) | ~5-6 min | ~3-4 min | same |

Most of our changes are SQL or source — the SQL row is the typical case.

## Test plan

- [ ] Merge → CI runs both build jobs in parallel → merge job stitches the manifest
- [ ] `docker buildx imagetools inspect cbioportal/mcp:latest` shows both amd64 and arm64 platforms
- [ ] Trivial follow-up SQL or comment change should build in ≤2 min instead of ≥5 min