### PR TITLE
Add per-study and alteration-type parameterized frequency views

### DIFF
--- a/sql/4-mutation-frequency-views.sql
+++ b/sql/4-mutation-frequency-views.sql
@@ -159,6 +159,195 @@ FROM altered a
 JOIN profiled p USING (cancer_type)
 WHERE p.profiled_samples >= 50;
 
+
+
+-- ============================================================================
+-- gene_mutation_frequency_in_study — per-study mutation frequency
+-- ============================================================================
+-- Same recipe as gene_mutation_frequency_by_cancer_type, but scoped to one
+-- explicit study instead of a cohort lookup. Use when the user names a
+-- specific study and that study isn't part of a shipped preference.
+--
+-- Parameters:
+--   study  — a cancer_study.cancer_study_identifier
+--            (e.g. 'brca_metabric', 'lung_msk_2017')
+--   gene   — HUGO gene symbol (e.g. 'TP53', 'KRAS')
+--
+-- Usage:
+--   SELECT *
+--   FROM gene_mutation_frequency_in_study(
+--       study='brca_metabric',
+--       gene='TP53'
+--   )
+--   ORDER BY frequency_pct DESC;
+--
+-- For single-cancer-type studies (most named studies), returns one row.
+-- For multi-cancer studies that carry a per-sample `CANCER_TYPE`
+-- attribute (e.g. msk_chord_2024), returns one row per cancer type with
+-- ≥ 50 profiled samples.
+-- ============================================================================
+
+DROP VIEW IF EXISTS gene_mutation_frequency_in_study;
+
+CREATE VIEW gene_mutation_frequency_in_study AS
+WITH sample_cancer_type AS (
+    SELECT cd.sample_unique_id, cd.attribute_value AS cancer_type
+    FROM clinical_data_derived cd
+    WHERE cd.cancer_study_identifier = {study:String}
+      AND cd.attribute_name = 'CANCER_TYPE'
+),
+altered AS (
+    SELECT sct.cancer_type,
+           COUNT(DISTINCT ged.sample_unique_id) AS altered_samples
+    FROM genomic_event_derived ged
+    JOIN sample_cancer_type sct USING (sample_unique_id)
+    WHERE ged.cancer_study_identifier = {study:String}
+      AND ged.variant_type = 'mutation'
+      AND ged.mutation_status != 'UNCALLED'
+      AND ged.hugo_gene_symbol = {gene:String}
+      AND ged.off_panel = 0
+    GROUP BY sct.cancer_type
+),
+profiled_samples_for_gene AS (
+    SELECT sample_unique_id, cancer_study_identifier
+    FROM mutation_panel_gene_coverage
+    WHERE hugo_gene_symbol = {gene:String}
+      AND cancer_study_identifier = {study:String}
+    UNION ALL
+    SELECT sample_unique_id, cancer_study_identifier
+    FROM mutation_wes_coverage
+    WHERE cancer_study_identifier = {study:String}
+),
+profiled AS (
+    SELECT sct.cancer_type,
+           COUNT(DISTINCT p.sample_unique_id) AS profiled_samples
+    FROM profiled_samples_for_gene p
+    JOIN sample_cancer_type sct USING (sample_unique_id)
+    GROUP BY sct.cancer_type
+)
+SELECT a.cancer_type,
+       a.altered_samples,
+       p.profiled_samples,
+       ROUND(a.altered_samples * 100.0 / NULLIF(p.profiled_samples, 0), 1) AS frequency_pct
+FROM altered a
+JOIN profiled p USING (cancer_type)
+WHERE p.profiled_samples >= 50;
+
+-- ============================================================================
+-- gene_alteration_frequency_by_cancer_type — generalize to CNA + SV
+-- ============================================================================
+-- gene_mutation_frequency_by_cancer_type only handles point mutations.
+-- This view generalizes the same recipe to copy-number alterations
+-- (amplification / deep deletion) and structural variants. The recipe is
+-- identical to the mutation case, with two differences:
+--   - numerator filter switches based on the alteration kind
+--   - denominator looks up samples profiled for the matching
+--     alteration_type in sample_to_gene_panel_derived
+--     (MUTATION_EXTENDED / COPY_NUMBER_ALTERATION / STRUCTURAL_VARIANT)
+--
+-- Parameters:
+--   preference  — cancer_study_query_preferences.preference_name (same as
+--                 gene_mutation_frequency_by_cancer_type)
+--   gene        — HUGO gene symbol
+--   alteration  — one of:
+--                   'mutation'           — point mutations (UNCALLED excluded)
+--                   'amplification'      — CNA == +2 (high-level amp)
+--                   'deep_deletion'      — CNA == -2 (homozygous deletion)
+--                   'structural_variant' — fusion / SV
+--
+-- Usage:
+--   SELECT * FROM gene_alteration_frequency_by_cancer_type(
+--       preference='pan_cancer_tcga', gene='MYC', alteration='amplification'
+--   ) ORDER BY frequency_pct DESC;
+--
+-- Returns the same columns as gene_mutation_frequency_by_cancer_type:
+-- (cancer_type, altered_samples, profiled_samples, frequency_pct).
+--
+-- For point mutations the result equals the mutation-only view;
+-- gene_mutation_frequency_by_cancer_type is kept as the cleaner
+-- shorthand for that case.
+-- ============================================================================
+
+DROP VIEW IF EXISTS gene_alteration_frequency_by_cancer_type;
+
+CREATE VIEW gene_alteration_frequency_by_cancer_type AS
+WITH cohort AS (
+    SELECT cancer_study_identifier
+    FROM cancer_study_query_preferences
+    WHERE preference_name = {preference:String}
+),
+sample_cancer_type AS (
+    SELECT cd.sample_unique_id, cd.attribute_value AS cancer_type
+    FROM clinical_data_derived cd
+    JOIN cohort c USING (cancer_study_identifier)
+    WHERE cd.attribute_name = 'CANCER_TYPE'
+),
+altered AS (
+    SELECT sct.cancer_type,
+           COUNT(DISTINCT ged.sample_unique_id) AS altered_samples
+    FROM genomic_event_derived ged
+    JOIN cohort c USING (cancer_study_identifier)
+    JOIN sample_cancer_type sct USING (sample_unique_id)
+    WHERE ged.hugo_gene_symbol = {gene:String}
+      AND ged.off_panel = 0
+      AND (
+        ({alteration:String} = 'mutation'
+            AND ged.variant_type = 'mutation'
+            AND ged.mutation_status != 'UNCALLED')
+        OR ({alteration:String} = 'amplification'
+            AND ged.variant_type = 'cna'
+            AND ged.cna_alteration = 2)
+        OR ({alteration:String} = 'deep_deletion'
+            AND ged.variant_type = 'cna'
+            AND ged.cna_alteration = -2)
+        OR ({alteration:String} = 'structural_variant'
+            AND ged.variant_type = 'structural_variant')
+      )
+    GROUP BY sct.cancer_type
+),
+profiled_samples_for_gene AS (
+    -- Map the user-facing alteration token to the alteration_type stored
+    -- on sample_to_gene_panel_derived. Same gene-in-panel-or-WES branch
+    -- as the mutation view, but with the matching alteration_type filter.
+    SELECT stgp.sample_unique_id, stgp.cancer_study_identifier
+    FROM sample_to_gene_panel_derived stgp
+    JOIN gene_panel gp ON stgp.gene_panel_id = gp.stable_id
+    JOIN gene_panel_list gpl ON gp.internal_id = gpl.internal_id
+    JOIN gene g ON gpl.gene_id = g.entrez_gene_id
+    WHERE g.hugo_gene_symbol = {gene:String}
+      AND stgp.alteration_type = multiIf(
+          {alteration:String} = 'mutation',           'MUTATION_EXTENDED',
+          {alteration:String} = 'amplification',      'COPY_NUMBER_ALTERATION',
+          {alteration:String} = 'deep_deletion',      'COPY_NUMBER_ALTERATION',
+          {alteration:String} = 'structural_variant', 'STRUCTURAL_VARIANT',
+          '')
+    UNION ALL
+    SELECT sample_unique_id, cancer_study_identifier
+    FROM sample_to_gene_panel_derived
+    WHERE gene_panel_id = 'WES'
+      AND alteration_type = multiIf(
+          {alteration:String} = 'mutation',           'MUTATION_EXTENDED',
+          {alteration:String} = 'amplification',      'COPY_NUMBER_ALTERATION',
+          {alteration:String} = 'deep_deletion',      'COPY_NUMBER_ALTERATION',
+          {alteration:String} = 'structural_variant', 'STRUCTURAL_VARIANT',
+          '')
+),
+profiled AS (
+    SELECT sct.cancer_type,
+           COUNT(DISTINCT p.sample_unique_id) AS profiled_samples
+    FROM profiled_samples_for_gene p
+    JOIN cohort c USING (cancer_study_identifier)
+    JOIN sample_cancer_type sct USING (sample_unique_id)
+    GROUP BY sct.cancer_type
+)
+SELECT a.cancer_type,
+       a.altered_samples,
+       p.profiled_samples,
+       ROUND(a.altered_samples * 100.0 / NULLIF(p.profiled_samples, 0), 1) AS frequency_pct
+FROM altered a
+JOIN profiled p USING (cancer_type)
+WHERE p.profiled_samples >= 50;
+
 -- ============================================================================
 -- top_mutated_genes_in_cohort — top-N most-mutated genes in a cohort
 -- ============================================================================

--- a/sql/4-mutation-frequency-views.sql
+++ b/sql/4-mutation-frequency-views.sql
@@ -234,6 +234,81 @@ JOIN profiled p USING (cancer_type)
 WHERE p.profiled_samples >= 50;
 
 -- ============================================================================
+-- gene_mutation_frequency_in_studies — ad-hoc cohort of named studies
+-- ============================================================================
+-- Same recipe as gene_mutation_frequency_in_study, but takes an Array of
+-- study ids. Use when the user names a handful of studies that aren't a
+-- shipped preference and there's no time to add one — e.g. "TP53 in
+-- METABRIC, MSK-IMPACT, and Pan-LungCancer".
+--
+-- IMPORTANT: this is your responsibility, not the view's: the studies
+-- you pass must NOT share samples. Sample IDs are study-prefixed
+-- (cancer_study_id_ + sample.stable_id), so the same physical sample
+-- in two studies will count twice and you can get >100% frequencies.
+-- The shipped preferences (`all_studies_non_redundant`, `pan_cancer_tcga`)
+-- are vetted to be non-overlapping; ad-hoc lists are not.
+--
+-- Parameters:
+--   studies  — Array(String) of cancer_study_identifier values
+--              (e.g. ['brca_metabric', 'brca_tcga_pan_can_atlas_2018'])
+--   gene     — HUGO gene symbol
+--
+-- Usage:
+--   SELECT *
+--   FROM gene_mutation_frequency_in_studies(
+--       studies=['brca_metabric','brca_tcga_pan_can_atlas_2018'],
+--       gene='TP53'
+--   )
+--   ORDER BY frequency_pct DESC;
+-- ============================================================================
+
+DROP VIEW IF EXISTS gene_mutation_frequency_in_studies;
+
+CREATE VIEW gene_mutation_frequency_in_studies AS
+WITH sample_cancer_type AS (
+    SELECT cd.sample_unique_id, cd.attribute_value AS cancer_type
+    FROM clinical_data_derived cd
+    WHERE cd.cancer_study_identifier IN {studies:Array(String)}
+      AND cd.attribute_name = 'CANCER_TYPE'
+),
+altered AS (
+    SELECT sct.cancer_type,
+           COUNT(DISTINCT ged.sample_unique_id) AS altered_samples
+    FROM genomic_event_derived ged
+    JOIN sample_cancer_type sct USING (sample_unique_id)
+    WHERE ged.cancer_study_identifier IN {studies:Array(String)}
+      AND ged.variant_type = 'mutation'
+      AND ged.mutation_status != 'UNCALLED'
+      AND ged.hugo_gene_symbol = {gene:String}
+      AND ged.off_panel = 0
+    GROUP BY sct.cancer_type
+),
+profiled_samples_for_gene AS (
+    SELECT sample_unique_id, cancer_study_identifier
+    FROM mutation_panel_gene_coverage
+    WHERE hugo_gene_symbol = {gene:String}
+      AND cancer_study_identifier IN {studies:Array(String)}
+    UNION ALL
+    SELECT sample_unique_id, cancer_study_identifier
+    FROM mutation_wes_coverage
+    WHERE cancer_study_identifier IN {studies:Array(String)}
+),
+profiled AS (
+    SELECT sct.cancer_type,
+           COUNT(DISTINCT p.sample_unique_id) AS profiled_samples
+    FROM profiled_samples_for_gene p
+    JOIN sample_cancer_type sct USING (sample_unique_id)
+    GROUP BY sct.cancer_type
+)
+SELECT a.cancer_type,
+       a.altered_samples,
+       p.profiled_samples,
+       ROUND(a.altered_samples * 100.0 / NULLIF(p.profiled_samples, 0), 1) AS frequency_pct
+FROM altered a
+JOIN profiled p USING (cancer_type)
+WHERE p.profiled_samples >= 50;
+
+-- ============================================================================
 -- gene_alteration_frequency_by_cancer_type — generalize to CNA + SV
 -- ============================================================================
 -- gene_mutation_frequency_by_cancer_type only handles point mutations.

--- a/src/cbioportal_mcp/resources/mutation-frequency-guide.md
+++ b/src/cbioportal_mcp/resources/mutation-frequency-guide.md
@@ -64,7 +64,67 @@ Returns `(cancer_type, altered_samples, profiled_samples, frequency_pct)` for ev
 
 The view is defined in `sql/4-mutation-frequency-views.sql` and handles the WES-vs-named-panel split internally (see "Why this works" below). The agent should prefer this view for any "gene X across cancer types in cohort Y" question instead of writing the JOIN chain by hand.
 
-For variations the view doesn't cover (top-N most-mutated genes per cancer type, comparing two specific cancer types, single-study queries that need extra filters), drop down to the expanded CTE form below and adapt — but start from this CTE form, not a from-scratch JOIN chain that risks missing the WES branch:
+### Variant: a single named study (`gene_mutation_frequency_in_study`)
+
+Use when the user names a specific study by id and that study isn't part of a shipped preference. Returns one row per cancer type with ≥ 50 profiled samples — typically one row for single-cancer-type studies (`brca_metabric`, `lung_msk_2017`, ...) and one row per cancer type for multi-cancer-type studies (`msk_chord_2024`).
+
+```sql
+SELECT *
+FROM gene_mutation_frequency_in_study(
+    study = 'brca_metabric',
+    gene  = 'TP53'
+)
+ORDER BY frequency_pct DESC;
+```
+
+Same WES-aware denominator handling as the cohort view.
+
+### Variant: copy-number or structural-variant alterations (`gene_alteration_frequency_by_cancer_type`)
+
+The cohort view above filters to point mutations only. For amplifications, deep deletions, or fusions/SVs, use the generalized view that takes an `alteration` token:
+
+```sql
+SELECT *
+FROM gene_alteration_frequency_by_cancer_type(
+    preference = 'pan_cancer_tcga',
+    gene       = 'MYC',
+    alteration = 'amplification'         -- or 'deep_deletion', 'structural_variant', 'mutation'
+)
+ORDER BY frequency_pct DESC;
+```
+
+Numerator and denominator both switch on the `alteration` parameter:
+
+| `alteration` token   | Counts (numerator)                              | Profiled denominator (alteration_type)  |
+|----------------------|-------------------------------------------------|-----------------------------------------|
+| `mutation`           | `variant_type='mutation'` AND `mutation_status != 'UNCALLED'` | `MUTATION_EXTENDED`                     |
+| `amplification`      | `variant_type='cna'` AND `cna_alteration = 2`   | `COPY_NUMBER_ALTERATION`                |
+| `deep_deletion`      | `variant_type='cna'` AND `cna_alteration = -2`  | `COPY_NUMBER_ALTERATION`                |
+| `structural_variant` | `variant_type='structural_variant'`             | `STRUCTURAL_VARIANT`                    |
+
+For `alteration='mutation'` the result equals `gene_mutation_frequency_by_cancer_type` (which is kept as the cleaner shorthand for that case).
+
+### Variant: top-N most-mutated genes in a cohort (`top_mutated_genes_in_cohort`)
+
+When the user asks "what are the most-mutated genes in cohort X" instead of naming a specific gene, use this view. Mirrors cbioportal-backend's `StudyViewMapper.getMutatedGenes` with the same WES-aware per-gene denominator as the gene-frequency view.
+
+```sql
+SELECT *
+FROM top_mutated_genes_in_cohort(
+    preference = 'pan_cancer_tcga',
+    top_n      = 20
+);
+```
+
+Returns `(hugo_gene_symbol, altered_samples, profiled_samples, frequency_pct, total_mutation_events)`, sorted by `altered_samples DESC` then gene symbol ASC (matching the backend's tiebreaker). Per-gene `profiled_samples` correctly reflects which samples were assayed for that gene — for targeted-panel cohorts (`large_genomic_cohort` = msk_impact_50k_2026), the denominator is samples on a panel that includes the gene; for WES cohorts (`pan_cancer_tcga`), every gene gets the same WES-sample denominator.
+
+### Variant: Spearman correlation between two genes
+
+Gene expression / copy-number correlation questions ("are TP53 and MYC expression correlated in METABRIC?") belong in `cbioportal://gene-expression-guide`, which covers the `genetic_alteration_derived` table and the `gene_pair_coexpression(study, gene_a, gene_b, profile_type)` view. Don't try to express expression queries through the mutation-frequency views.
+
+### When to drop down to the expanded CTE form
+
+For variations none of these three views cover (top-N most-mutated genes per cancer type, comparing two specific cancer types, custom alteration filters), drop down to the expanded CTE form below and adapt — but start from this CTE form, not a from-scratch JOIN chain that risks missing the WES branch:
 
 ```sql
 WITH cohort AS (
@@ -115,24 +175,6 @@ JOIN profiled p USING (cancer_type)
 WHERE p.profiled_samples >= 50  -- suppress tiny cancer types
 ORDER BY frequency_pct DESC;
 ```
-
-### Variant: top-N most-mutated genes in a cohort (`top_mutated_genes_in_cohort`)
-
-When the user asks "what are the most-mutated genes in cohort X" instead of naming a specific gene, use this view. Mirrors cbioportal-backend's `StudyViewMapper.getMutatedGenes` with the same WES-aware per-gene denominator as the gene-frequency view.
-
-```sql
-SELECT *
-FROM top_mutated_genes_in_cohort(
-    preference = 'pan_cancer_tcga',
-    top_n      = 20
-);
-```
-
-Returns `(hugo_gene_symbol, altered_samples, profiled_samples, frequency_pct, total_mutation_events)`, sorted by `altered_samples DESC` then gene symbol ASC (matching the backend's tiebreaker). Per-gene `profiled_samples` correctly reflects which samples were assayed for that gene — for targeted-panel cohorts (`large_genomic_cohort` = msk_impact_50k_2026), the denominator is samples on a panel that includes the gene; for WES cohorts (`pan_cancer_tcga`), every gene gets the same WES-sample denominator.
-
-### Variant: Spearman correlation between two genes
-
-Gene expression / copy-number correlation questions ("are TP53 and MYC expression correlated in METABRIC?") belong in `cbioportal://gene-expression-guide`, which covers the `genetic_alteration_derived` table and the `gene_pair_coexpression(study, gene_a, gene_b, profile_type)` view. Don't try to express expression queries through the mutation-frequency views.
 
 ### Why this works
 - **`cancer_study_query_preferences` enforces a non-overlapping cohort.** Every shipped preference resolves to studies with no shared samples, so `COUNT(DISTINCT sample_unique_id)` doesn't double-count.

--- a/src/cbioportal_mcp/resources/mutation-frequency-guide.md
+++ b/src/cbioportal_mcp/resources/mutation-frequency-guide.md
@@ -79,6 +79,21 @@ ORDER BY frequency_pct DESC;
 
 Same WES-aware denominator handling as the cohort view.
 
+### Variant: a handful of named studies (`gene_mutation_frequency_in_studies`)
+
+Use when the user names two or more studies that aren't a shipped preference and aren't worth defining one for — e.g. *"TP53 in METABRIC and TCGA Pan-Cancer Atlas breast"*. Takes an `Array(String)` of study ids:
+
+```sql
+SELECT *
+FROM gene_mutation_frequency_in_studies(
+    studies = ['brca_metabric', 'brca_tcga_pan_can_atlas_2018'],
+    gene    = 'TP53'
+)
+ORDER BY frequency_pct DESC;
+```
+
+**You are responsible for non-overlap.** Sample IDs are study-prefixed (`<study_id>_<sample.stable_id>`), so the same physical sample appearing in two studies under different IDs WILL be double-counted by this view and produce a frequency that's higher than reality. The shipped preferences (`all_studies_non_redundant`, `pan_cancer_tcga`) are vetted to be non-overlapping; ad-hoc lists are not. If you can't vouch for non-overlap, fall back to the single-study view or a shipped preference.
+
 ### Variant: copy-number or structural-variant alterations (`gene_alteration_frequency_by_cancer_type`)
 
 The cohort view above filters to point mutations only. For amplifications, deep deletions, or fusions/SVs, use the generalized view that takes an `alteration` token:


### PR DESCRIPTION
Follow-up to #49 / #50. The parameterized `gene_mutation_frequency_by_cancer_type(preference, gene)` only works for cohorts named in `cancer_study_query_preferences` and only for point mutations. Two new views cover the natural extensions.

## Views

### `gene_mutation_frequency_in_study(study, gene)`

Same recipe, scoped to one explicit study id. Use when the user names a study not in a shipped preference (`brca_metabric`, `lung_msk_2017`, …).

```sql
SELECT * FROM gene_mutation_frequency_in_study(study='brca_metabric', gene='TP53');
-- → Breast Cancer  864/2433  35.5%
```

For multi-cancer-type studies (msk_chord_2024), returns one row per cancer type with ≥ 50 profiled samples — same shape as the cohort view.

### `gene_alteration_frequency_by_cancer_type(preference, gene, alteration)`

Generalizes the cohort recipe to CNA + structural variants via an `alteration` token:

| Token | Numerator filter | Profiled `alteration_type` |
|---|---|---|
| `mutation` | `variant_type='mutation'` AND `mutation_status != 'UNCALLED'` | `MUTATION_EXTENDED` |
| `amplification` | `variant_type='cna'` AND `cna_alteration = 2` | `COPY_NUMBER_ALTERATION` |
| `deep_deletion` | `variant_type='cna'` AND `cna_alteration = -2` | `COPY_NUMBER_ALTERATION` |
| `structural_variant` | `variant_type='structural_variant'` | `STRUCTURAL_VARIANT` |

```sql
SELECT * FROM gene_alteration_frequency_by_cancer_type(
    preference='pan_cancer_tcga', gene='MYC', alteration='amplification'
);
-- → Ovarian Epithelial Tumor  190/572  33.2%
--   Breast Cancer             161/1070 15.0%
```

For `alteration='mutation'` the rows are identical to `gene_mutation_frequency_by_cancer_type`; the mutation-only view is kept as the cleaner shorthand for that case.

## Verified live (against cbioportal_public_librechat_green)

- **In-study, single-cancer:** TP53 in `brca_metabric` = 35.5% (864/2433) — matches published breast TP53.
- **In-study, multi-cancer:** TP53 in `msk_chord_2024`: Colorectal 73.4%, Pancreatic 66.8%, NSCLC 51.3% — identical to `gene_mutation_frequency_by_cancer_type(preference='treatment_outcomes', gene='TP53')`.
- **Amplification:** MYC amp in `pan_cancer_tcga`: Ovarian Epithelial Tumor 33.2%, Breast 15.0%.
- **Deep deletion:** CDKN2A deep_deletion in `pan_cancer_tcga`: Glioblastoma 56.0%, Mesothelioma 44.8%, Bladder 31.9% — textbook for CDKN2A in GBM.
- **Equivalence:** `gene_alteration_frequency_by_cancer_type(..., alteration='mutation')` returns identical rows to `gene_mutation_frequency_by_cancer_type(...)`.

## Guide

`mutation-frequency-guide.md` gains two "Variant:" sections under the canonical recipe — one per new view — with usage blocks and the alteration-token mapping table. The expanded CTE form is preserved as the "drop down to this if no view fits" pattern (still useful for top-N-genes-per-cancer-type, comparing two specific cancer types, or non-shipped preferences).

## Test plan

- [ ] Merge — image rebuild publishes the updated guide.
- [ ] Apply `sql/4-mutation-coverage-views.sql` to the active LLM clone via `scripts/apply_sql.sh` (no full re-clone needed; views are pure DDL). Already applied to `cbioportal_public_librechat_green` for verification.
- [ ] Roll the MCP pod so the agent serves the updated guide.
- [ ] Smoke test agent answers for: "MYC amplifications across cancer types" → should hit the alteration view with `amplification`; "TP53 in METABRIC" → should hit the in-study view.