### PR TITLE
Add top-mutated-genes-in-cohort and gene-pair-coexpression views

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,4 +70,4 @@ clickhouse-data/
 *.log
 
 # Local configuration
-.env.local
+.env.localsql/clone_db.sql

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,8 @@ SQL scripts in `sql/` directory (numeric prefix = apply order; see `sql/README.m
 - `1-add-column-comments.sql` - Adds helpful column comments
 - `2-add-oncotree-fields.sql` - Denormalizes OncoTree onto `type_of_cancer`
 - `3-add-cancer-study-query-preferences.sql` - Creates the cohort-lookup table
-- `4-mutation-coverage-views.sql` - WES-aware views for mutation-frequency denominators + parameterized `gene_mutation_frequency_by_cancer_type(preference, gene)` recipe view
+- `4-mutation-frequency-views.sql` - WES-aware views for mutation-frequency denominators + parameterized `gene_mutation_frequency_by_cancer_type(preference, gene)` recipe view + `top_mutated_genes_in_cohort`
+- `5-gene-expression-views.sql` - Expression / copy-number-value / methylation views (`gene_pair_coexpression`); backed by `genetic_alteration_derived`
 - `portal-specific/<portal-name>/*.sql` - Deployment-specific cohorts (e.g. `portal-specific/public-portal/0-preferences.sql`). Existence-gated so they're no-ops on other deployments.
 
 **Example**: The `sample.sample_type` column contained "Primary Solid Tumor" for ALL samples, causing agents to report wrong counts for "primary samples". Solution: Remove the column entirely.
@@ -131,7 +132,8 @@ sql/
 ├── 1-add-column-comments.sql                    # Add helpful column comments
 ├── 2-add-oncotree-fields.sql                    # Denormalize OncoTree onto type_of_cancer
 ├── 3-add-cancer-study-query-preferences.sql     # cancer_study_query_preferences table + portable preferences
-├── 4-mutation-coverage-views.sql                # WES-aware views for mutation-frequency denominators
+├── 4-mutation-frequency-views.sql                # Mutation-frequency parameterized views + coverage building blocks
+├── 5-gene-expression-views.sql                   # Expression / CN / methylation correlation views
 └── portal-specific/                             # Deployment-specific preferences (iterated after portable files)
     └── public-portal/
         └── 0-preferences.sql                    # cbioportal.org cohort rows (gated, no-op elsewhere)

--- a/sql/4-mutation-coverage-views.sql
+++ b/sql/4-mutation-coverage-views.sql
@@ -140,3 +140,139 @@ SELECT a.cancer_type,
 FROM altered a
 JOIN profiled p USING (cancer_type)
 WHERE p.profiled_samples >= 50;
+
+-- ============================================================================
+-- top_mutated_genes_in_cohort — top-N most-mutated genes in a cohort
+-- ============================================================================
+-- Mirrors cbioportal-backend's StudyViewMapper.getMutatedGenes, but with
+-- a WES-aware gene-specific profiled denominator (so the percentage
+-- reflects real biology instead of being inflated for low-coverage
+-- genes).
+--
+-- The trick to keeping this cheap at cohort scale: WES samples are
+-- profiled for ALL genes, so their count is a single number per cohort
+-- (computed once). For named-panel samples, profiled count is per-gene
+-- and only needs to include the genes the panel actually lists. We
+-- compute these two pieces separately and add them per gene.
+--
+-- Parameters:
+--   preference  — cancer_study_query_preferences.preference_name
+--                 (e.g. 'pan_cancer_tcga' default; see
+--                 gene_mutation_frequency_by_cancer_type docstring)
+--   top_n       — UInt32, max number of genes to return
+--                 (e.g. 20 for the typical "top 20 mutated genes" question)
+--
+-- Usage:
+--   SELECT *
+--   FROM top_mutated_genes_in_cohort(
+--       preference='pan_cancer_tcga',
+--       top_n=20
+--   );
+--
+-- Returns one row per gene: (hugo_gene_symbol, altered_samples,
+-- profiled_samples, frequency_pct, total_mutation_events). Sorted by
+-- altered_samples DESC, then hugo_gene_symbol ASC (same as backend).
+-- ============================================================================
+
+DROP VIEW IF EXISTS top_mutated_genes_in_cohort;
+
+CREATE VIEW top_mutated_genes_in_cohort AS
+WITH cohort AS (
+    SELECT cancer_study_identifier
+    FROM cancer_study_query_preferences
+    WHERE preference_name = {preference:String}
+),
+wes_profiled_count AS (
+    -- WES samples are profiled for every gene; one number for the cohort.
+    SELECT COUNT(DISTINCT w.sample_unique_id) AS n
+    FROM mutation_wes_coverage w
+    JOIN cohort c USING (cancer_study_identifier)
+),
+panel_profiled_per_gene AS (
+    -- For each gene, count cohort samples on a named panel that lists it.
+    SELECT mpgc.hugo_gene_symbol, COUNT(DISTINCT mpgc.sample_unique_id) AS n
+    FROM mutation_panel_gene_coverage mpgc
+    JOIN cohort c USING (cancer_study_identifier)
+    GROUP BY mpgc.hugo_gene_symbol
+),
+altered_per_gene AS (
+    SELECT ged.hugo_gene_symbol,
+           COUNT(DISTINCT ged.sample_unique_id) AS altered_samples,
+           COUNT(*) AS total_mutation_events
+    FROM genomic_event_derived ged
+    JOIN cohort c USING (cancer_study_identifier)
+    WHERE ged.variant_type = 'mutation'
+      AND ged.mutation_status != 'UNCALLED'
+      AND ged.off_panel = 0
+    GROUP BY ged.hugo_gene_symbol
+)
+SELECT a.hugo_gene_symbol,
+       a.altered_samples,
+       (SELECT n FROM wes_profiled_count) + COALESCE(p.n, 0) AS profiled_samples,
+       ROUND(a.altered_samples * 100.0 / NULLIF((SELECT n FROM wes_profiled_count) + COALESCE(p.n, 0), 0), 1) AS frequency_pct,
+       a.total_mutation_events
+FROM altered_per_gene a
+LEFT JOIN panel_profiled_per_gene p USING (hugo_gene_symbol)
+ORDER BY altered_samples DESC, hugo_gene_symbol ASC
+LIMIT {top_n:UInt32};
+
+-- ============================================================================
+-- gene_pair_coexpression — Spearman correlation between two genes
+-- ============================================================================
+-- Mirrors cbioportal-backend's ClickhouseCoExpressionMapper.getCoExpressions,
+-- simplified to a pair-of-genes lookup (the backend computes one ref
+-- gene vs all other genes for the coexpression page; here the agent
+-- asks about a specific pair like "TP53 vs MYC").
+--
+-- Parameters:
+--   study         — cancer_study.cancer_study_identifier
+--                   (single study; expression profiles are study-scoped)
+--   gene_a        — first HUGO gene symbol
+--   gene_b        — second HUGO gene symbol
+--   profile_type  — one of the values in genetic_alteration_derived.profile_type
+--                   Common: 'mrna', 'mrna_median_Zscores',
+--                   'mrna_seq_v2_rsem', 'mrna_seq_v2_rsem_Zscores'
+--                   Discover available: SELECT DISTINCT profile_type
+--                   FROM genetic_alteration_derived
+--                   WHERE cancer_study_identifier = '<study>'
+--
+-- Usage:
+--   SELECT * FROM gene_pair_coexpression(
+--       study='brca_metabric',
+--       gene_a='TP53',
+--       gene_b='MYC',
+--       profile_type='mrna'
+--   );
+--
+-- Returns one row: (gene_a, gene_b, profile_type,
+-- spearman_correlation, num_samples). spearman_correlation is in
+-- [-1, 1]; NULL if fewer than 3 samples have valid pair values.
+-- ============================================================================
+
+DROP VIEW IF EXISTS gene_pair_coexpression;
+
+CREATE VIEW gene_pair_coexpression AS
+WITH a AS (
+    SELECT sample_unique_id, toFloat64OrNull(alteration_value) AS v
+    FROM genetic_alteration_derived
+    WHERE cancer_study_identifier = {study:String}
+      AND profile_type = {profile_type:String}
+      AND hugo_gene_symbol = {gene_a:String}
+      AND alteration_value NOT IN ('', 'NA')
+      AND toFloat64OrNull(alteration_value) IS NOT NULL
+),
+b AS (
+    SELECT sample_unique_id, toFloat64OrNull(alteration_value) AS v
+    FROM genetic_alteration_derived
+    WHERE cancer_study_identifier = {study:String}
+      AND profile_type = {profile_type:String}
+      AND hugo_gene_symbol = {gene_b:String}
+      AND alteration_value NOT IN ('', 'NA')
+      AND toFloat64OrNull(alteration_value) IS NOT NULL
+)
+SELECT {gene_a:String}      AS gene_a,
+       {gene_b:String}      AS gene_b,
+       {profile_type:String} AS profile_type,
+       if(count() >= 3, rankCorr(a.v, b.v), NULL) AS spearman_correlation,
+       count() AS num_samples
+FROM a INNER JOIN b USING (sample_unique_id);

--- a/sql/4-mutation-frequency-views.sql
+++ b/sql/4-mutation-frequency-views.sql
@@ -1,4 +1,22 @@
 -- ============================================================================
+-- Mutation-frequency views (coverage building blocks + frequency recipes)
+-- ============================================================================
+-- This file is the mutation side of the agent's gene-frequency API:
+--   - Two coverage building-block views (`mutation_panel_gene_coverage`,
+--     `mutation_wes_coverage`).
+--   - Parameterized "frequency by cancer type for cohort Y" recipe.
+--   - Parameterized "top-N most-mutated genes in cohort" recipe.
+--
+-- Sibling files in this directory:
+--   sql/5-gene-expression-views.sql — gene_pair_coexpression and any
+--     other expression / copy-number-value / methylation correlation
+--     views. Anything backed by `genetic_alteration_derived` lives
+--     there, not here.
+--
+-- The agent-facing docs are at `cbioportal://mutation-frequency-guide`.
+-- ============================================================================
+
+-- ============================================================================
 -- mutation_panel_gene_coverage + mutation_wes_coverage
 -- ============================================================================
 -- The canonical "is this sample profiled for gene G?" query has to handle
@@ -216,63 +234,3 @@ LEFT JOIN panel_profiled_per_gene p USING (hugo_gene_symbol)
 ORDER BY altered_samples DESC, hugo_gene_symbol ASC
 LIMIT {top_n:UInt32};
 
--- ============================================================================
--- gene_pair_coexpression — Spearman correlation between two genes
--- ============================================================================
--- Mirrors cbioportal-backend's ClickhouseCoExpressionMapper.getCoExpressions,
--- simplified to a pair-of-genes lookup (the backend computes one ref
--- gene vs all other genes for the coexpression page; here the agent
--- asks about a specific pair like "TP53 vs MYC").
---
--- Parameters:
---   study         — cancer_study.cancer_study_identifier
---                   (single study; expression profiles are study-scoped)
---   gene_a        — first HUGO gene symbol
---   gene_b        — second HUGO gene symbol
---   profile_type  — one of the values in genetic_alteration_derived.profile_type
---                   Common: 'mrna', 'mrna_median_Zscores',
---                   'mrna_seq_v2_rsem', 'mrna_seq_v2_rsem_Zscores'
---                   Discover available: SELECT DISTINCT profile_type
---                   FROM genetic_alteration_derived
---                   WHERE cancer_study_identifier = '<study>'
---
--- Usage:
---   SELECT * FROM gene_pair_coexpression(
---       study='brca_metabric',
---       gene_a='TP53',
---       gene_b='MYC',
---       profile_type='mrna'
---   );
---
--- Returns one row: (gene_a, gene_b, profile_type,
--- spearman_correlation, num_samples). spearman_correlation is in
--- [-1, 1]; NULL if fewer than 3 samples have valid pair values.
--- ============================================================================
-
-DROP VIEW IF EXISTS gene_pair_coexpression;
-
-CREATE VIEW gene_pair_coexpression AS
-WITH a AS (
-    SELECT sample_unique_id, toFloat64OrNull(alteration_value) AS v
-    FROM genetic_alteration_derived
-    WHERE cancer_study_identifier = {study:String}
-      AND profile_type = {profile_type:String}
-      AND hugo_gene_symbol = {gene_a:String}
-      AND alteration_value NOT IN ('', 'NA')
-      AND toFloat64OrNull(alteration_value) IS NOT NULL
-),
-b AS (
-    SELECT sample_unique_id, toFloat64OrNull(alteration_value) AS v
-    FROM genetic_alteration_derived
-    WHERE cancer_study_identifier = {study:String}
-      AND profile_type = {profile_type:String}
-      AND hugo_gene_symbol = {gene_b:String}
-      AND alteration_value NOT IN ('', 'NA')
-      AND toFloat64OrNull(alteration_value) IS NOT NULL
-)
-SELECT {gene_a:String}      AS gene_a,
-       {gene_b:String}      AS gene_b,
-       {profile_type:String} AS profile_type,
-       if(count() >= 3, rankCorr(a.v, b.v), NULL) AS spearman_correlation,
-       count() AS num_samples
-FROM a INNER JOIN b USING (sample_unique_id);

--- a/sql/5-gene-expression-views.sql
+++ b/sql/5-gene-expression-views.sql
@@ -1,0 +1,71 @@
+-- ============================================================================
+-- Gene expression / molecular-correlation views
+-- ============================================================================
+-- Companion to sql/4-mutation-frequency-views.sql but for the continuous-
+-- value side of the cBioPortal schema: gene expression, copy-number
+-- values, methylation. Backed by `genetic_alteration_derived` (a long
+-- table keyed by sample + study + gene + profile_type).
+--
+-- The agent-facing docs are at `cbioportal://gene-expression-guide`.
+-- ============================================================================
+
+-- ============================================================================
+-- gene_pair_coexpression — Spearman correlation between two genes
+-- ============================================================================
+-- Mirrors cbioportal-backend's ClickhouseCoExpressionMapper.getCoExpressions,
+-- simplified to a pair-of-genes lookup (the backend computes one ref
+-- gene vs all other genes for the coexpression page; here the agent
+-- asks about a specific pair like "TP53 vs MYC").
+--
+-- Parameters:
+--   study         — cancer_study.cancer_study_identifier
+--                   (single study; expression profiles are study-scoped)
+--   gene_a        — first HUGO gene symbol
+--   gene_b        — second HUGO gene symbol
+--   profile_type  — one of the values in genetic_alteration_derived.profile_type
+--                   Common: 'mrna', 'mrna_median_Zscores',
+--                   'mrna_seq_v2_rsem', 'mrna_seq_v2_rsem_Zscores'
+--                   Discover available: SELECT DISTINCT profile_type
+--                   FROM genetic_alteration_derived
+--                   WHERE cancer_study_identifier = '<study>'
+--
+-- Usage:
+--   SELECT * FROM gene_pair_coexpression(
+--       study='brca_metabric',
+--       gene_a='TP53',
+--       gene_b='MYC',
+--       profile_type='mrna'
+--   );
+--
+-- Returns one row: (gene_a, gene_b, profile_type,
+-- spearman_correlation, num_samples). spearman_correlation is in
+-- [-1, 1]; NULL if fewer than 3 samples have valid pair values.
+-- ============================================================================
+
+DROP VIEW IF EXISTS gene_pair_coexpression;
+
+CREATE VIEW gene_pair_coexpression AS
+WITH a AS (
+    SELECT sample_unique_id, toFloat64OrNull(alteration_value) AS v
+    FROM genetic_alteration_derived
+    WHERE cancer_study_identifier = {study:String}
+      AND profile_type = {profile_type:String}
+      AND hugo_gene_symbol = {gene_a:String}
+      AND alteration_value NOT IN ('', 'NA')
+      AND toFloat64OrNull(alteration_value) IS NOT NULL
+),
+b AS (
+    SELECT sample_unique_id, toFloat64OrNull(alteration_value) AS v
+    FROM genetic_alteration_derived
+    WHERE cancer_study_identifier = {study:String}
+      AND profile_type = {profile_type:String}
+      AND hugo_gene_symbol = {gene_b:String}
+      AND alteration_value NOT IN ('', 'NA')
+      AND toFloat64OrNull(alteration_value) IS NOT NULL
+)
+SELECT {gene_a:String}      AS gene_a,
+       {gene_b:String}      AS gene_b,
+       {profile_type:String} AS profile_type,
+       if(count() >= 3, rankCorr(a.v, b.v), NULL) AS spearman_correlation,
+       count() AS num_samples
+FROM a INNER JOIN b USING (sample_unique_id);

--- a/sql/README.md
+++ b/sql/README.md
@@ -13,7 +13,8 @@ MCP agent can reason about it.
 | 1 | `1-add-column-comments.sql` | Attach human-readable `COMMENT`s so the agent can self-introspect column meaning. |
 | 2 | `2-add-oncotree-fields.sql` | Add OncoTree fields to `type_of_cancer` (auto-generated). |
 | 3 | `3-add-cancer-study-query-preferences.sql` | Creates `cancer_study_query_preferences` table + pattern-detected preferences (currently `pan_cancer_tcga`). |
-| 4 | `4-mutation-coverage-views.sql` | Creates `mutation_panel_gene_coverage` + `mutation_wes_coverage` building-block views and the parameterized `gene_mutation_frequency_by_cancer_type(preference, gene)` recipe view. Handles the "WES is not in `gene_panel`" trap that produces >100% frequencies. See `cbioportal://mutation-frequency-guide`. |
+| 4 | `4-mutation-frequency-views.sql` | Mutation-frequency parameterized views (`gene_mutation_frequency_by_cancer_type`, `top_mutated_genes_in_cohort`) and the two coverage building-block views (`mutation_panel_gene_coverage`, `mutation_wes_coverage`). Handles the "WES is not in `gene_panel`" trap that produces >100% frequencies. See `cbioportal://mutation-frequency-guide`. |
+| 5 | `5-gene-expression-views.sql` | Gene-expression / copy-number-value / methylation views, backed by `genetic_alteration_derived`. Currently `gene_pair_coexpression(study, gene_a, gene_b, profile_type)` for Spearman correlation between two genes. See `cbioportal://gene-expression-guide`. |
 
 Everything under `sql/` directly is **portable** — works against any cBioPortal deployment. Deployment-specific SQL lives under `sql/portal-specific/<portal-name>/`:
 

--- a/src/cbioportal_mcp/resources/gene-expression-guide.md
+++ b/src/cbioportal_mcp/resources/gene-expression-guide.md
@@ -1,0 +1,106 @@
+# Gene Expression Analysis Guide
+
+This guide covers continuous-value genomic data: gene **expression**, **copy number** values, **methylation**, and related profile types. Mutation/CNA/SV *frequency* analysis lives in `cbioportal://mutation-frequency-guide`.
+
+## Where this data lives
+
+Continuous per-sample-per-gene values are stored in `genetic_alteration_derived`:
+
+| Column | Description |
+|---|---|
+| `sample_unique_id` | `<study>_<sample_stable_id>` |
+| `cancer_study_identifier` | study scope |
+| `hugo_gene_symbol` | gene |
+| `profile_type` | which assay/normalization (see below) |
+| `alteration_value` | the actual value — stored as Nullable(String); cast with `toFloat64OrNull` |
+
+`alteration_value` is a string because the same column hosts many different value scales. The `''` and `'NA'` sentinels mean "missing"; always filter them out and use `toFloat64OrNull(alteration_value) IS NOT NULL` for downstream math.
+
+## Discovering profile types for a study
+
+Different studies expose different profile types depending on what assays were run and how the data was normalized. Always check what a specific study supports before picking one:
+
+```sql
+SELECT DISTINCT profile_type
+FROM genetic_alteration_derived
+WHERE cancer_study_identifier = 'brca_metabric'
+ORDER BY profile_type;
+```
+
+Common values across the public portal:
+
+| Family | Profile types |
+|---|---|
+| mRNA expression | `mrna`, `mrna_median_Zscores`, `mrna_seq_v2_rsem`, `mrna_seq_v2_rsem_Zscores`, `mrna_seq_cpm`, `mrna_seq_fpkm`, `mrna_U133`, `mrna_outliers` |
+| Copy number (continuous) | `cna`, `linear_CNA`, `log2CNA`, `cna_consensus`, `cna_rae`, `gistic` |
+| Methylation | `methylation_hm27`, `methylation_hm450`, `methylation_epic`, `methylation_promoters_rrbs` |
+| miRNA | `mirna`, `mirna_median_Zscores` |
+| Protein | `protein_quantification`, `protein_level`, `RPPA` |
+
+**Z-score vs raw choice.** When the user asks "is X correlated with Y", either works for Spearman (rank-based) — Pearson would care. Default to the non-Z-score variant if both exist, and call out which one in the response.
+
+## Canonical recipe — Spearman correlation between two genes
+
+```sql
+SELECT *
+FROM gene_pair_coexpression(
+    study        = 'brca_metabric',
+    gene_a       = 'TP53',
+    gene_b       = 'MYC',
+    profile_type = 'mrna'
+);
+```
+
+Returns one row: `(gene_a, gene_b, profile_type, spearman_correlation, num_samples)`.
+
+- `spearman_correlation` in [−1, 1]; `NULL` when fewer than 3 valid paired samples.
+- Mirrors cbioportal-backend's `ClickhouseCoExpressionMapper.getCoExpressions`, simplified to a pair lookup (the backend computes one ref gene vs ALL other genes for the coexpression page; here the agent asks about a specific pair).
+
+### Verified examples
+
+| Study | gene_a | gene_b | profile_type | spearman | n |
+|---|---|---|---|---|---|
+| `brca_metabric` | TP53 | MYC | `mrna` | 0.118 | 1980 |
+| `brca_metabric` | ESR1 | PGR | `mrna` | 0.487 | 1980 |
+
+ESR1↔PGR is the textbook breast-cancer estrogen-receptor coregulation; the 0.49 is a useful "this is what a real signal looks like" reference.
+
+## When NOT to use `gene_pair_coexpression`
+
+- **Mutation–mutation co-occurrence.** Spearman on essentially-binary inputs (mutated vs not) returns near-zero regardless of true co-occurrence. The agent should compute a 2×2 sample contingency table (gene_a mutated × gene_b mutated) and run Fisher's exact / log odds-ratio. See `cbioportal://statistical-tests-guide` for the decision matrix and `cBioPortal/cbioportal-navigator#43` for the real-world failure mode.
+- **Survival vs gene expression.** Spearman correlates two continuous variables; survival analysis (Cox PH, Kaplan-Meier) is a different shape. Use `clinical_data_derived` + `clinical_event_derived` and surface the data; let the user run the survival test in R/Python/cBioPortal's Comparison tab.
+- **Mutation count vs expression** (TMB ↔ a gene). Spearman is fine if both axes are continuous — compute TMB per sample (e.g. mutation count in `genomic_event_derived`) and join with the gene's expression. The pair-view doesn't cover this; the agent should write the CTE directly.
+
+## Expanded CTE form for variations the view doesn't cover
+
+If you need to filter samples (e.g. restrict to a subtype), correlate with a non-gene attribute (TMB, age), or correlate against multiple genes at once, drop down to the CTE form:
+
+```sql
+WITH a AS (
+    SELECT sample_unique_id, toFloat64OrNull(alteration_value) AS v
+    FROM genetic_alteration_derived
+    WHERE cancer_study_identifier = 'brca_metabric'
+      AND profile_type = 'mrna'
+      AND hugo_gene_symbol = 'TP53'
+      AND alteration_value NOT IN ('', 'NA')
+      AND toFloat64OrNull(alteration_value) IS NOT NULL
+),
+b AS (
+    SELECT sample_unique_id, toFloat64OrNull(alteration_value) AS v
+    FROM genetic_alteration_derived
+    WHERE cancer_study_identifier = 'brca_metabric'
+      AND profile_type = 'mrna'
+      AND hugo_gene_symbol = 'MYC'
+      AND alteration_value NOT IN ('', 'NA')
+      AND toFloat64OrNull(alteration_value) IS NOT NULL
+)
+SELECT rankCorr(a.v, b.v) AS spearman_correlation,
+       count() AS num_samples
+FROM a INNER JOIN b USING (sample_unique_id);
+```
+
+The view's job is to encode this shape once and force the `alteration_value NOT IN ('', 'NA')` + `toFloat64OrNull(...) IS NOT NULL` filters so a forgotten one doesn't silently corrupt the correlation.
+
+## Cross-study correlation
+
+`genetic_alteration_derived.profile_type` values are study-scoped — `mrna` in METABRIC isn't directly comparable to `mrna` in TCGA-BRCA because the underlying assays and normalizations differ. To pool across studies, use a Z-scored profile type that exists in both (`mrna_median_Zscores` is the most common) and document the caveat in the response. Or stay within a single study.

--- a/src/cbioportal_mcp/resources/mutation-frequency-guide.md
+++ b/src/cbioportal_mcp/resources/mutation-frequency-guide.md
@@ -130,34 +130,9 @@ FROM top_mutated_genes_in_cohort(
 
 Returns `(hugo_gene_symbol, altered_samples, profiled_samples, frequency_pct, total_mutation_events)`, sorted by `altered_samples DESC` then gene symbol ASC (matching the backend's tiebreaker). Per-gene `profiled_samples` correctly reflects which samples were assayed for that gene — for targeted-panel cohorts (`large_genomic_cohort` = msk_impact_50k_2026), the denominator is samples on a panel that includes the gene; for WES cohorts (`pan_cancer_tcga`), every gene gets the same WES-sample denominator.
 
-### Variant: Spearman correlation between two genes (`gene_pair_coexpression`)
+### Variant: Spearman correlation between two genes
 
-When the user asks whether two genes' expression (or copy number, methylation, etc.) is correlated in a study, use this view. Mirrors cbioportal-backend's `ClickhouseCoExpressionMapper.getCoExpressions`, simplified to the typical agent question of *one pair of genes* rather than one ref gene vs all others.
-
-```sql
-SELECT *
-FROM gene_pair_coexpression(
-    study         = 'brca_metabric',
-    gene_a        = 'TP53',
-    gene_b        = 'MYC',
-    profile_type  = 'mrna'
-);
-```
-
-Returns one row: `(gene_a, gene_b, profile_type, spearman_correlation, num_samples)`. `spearman_correlation` is in [−1, 1]; `NULL` when fewer than 3 valid paired samples.
-
-Discover available profile types for a study:
-
-```sql
-SELECT DISTINCT profile_type
-FROM genetic_alteration_derived
-WHERE cancer_study_identifier = 'brca_metabric'
-ORDER BY profile_type;
-```
-
-Common values: `mrna`, `mrna_median_Zscores`, `mrna_seq_v2_rsem`, `mrna_seq_v2_rsem_Zscores` for expression; `cna`, `linear_CNA`, `gistic` for copy number; `methylation_*` for methylation.
-
-> **Don't use this view to claim "co-occurrence of mutations".** Spearman correlation is for continuous values (expression, copy number). For mutation–mutation co-occurrence the agent should compute a 2×2 sample contingency table and run Fisher's exact / log odds-ratio — `gene_pair_coexpression` will silently return something close to 0 because the input is essentially two binary columns and Spearman is the wrong tool.
+Gene expression / copy-number correlation questions ("are TP53 and MYC expression correlated in METABRIC?") belong in `cbioportal://gene-expression-guide`, which covers the `genetic_alteration_derived` table and the `gene_pair_coexpression(study, gene_a, gene_b, profile_type)` view. Don't try to express expression queries through the mutation-frequency views.
 
 ### Why this works
 - **`cancer_study_query_preferences` enforces a non-overlapping cohort.** Every shipped preference resolves to studies with no shared samples, so `COUNT(DISTINCT sample_unique_id)` doesn't double-count.

--- a/src/cbioportal_mcp/resources/mutation-frequency-guide.md
+++ b/src/cbioportal_mcp/resources/mutation-frequency-guide.md
@@ -116,6 +116,49 @@ WHERE p.profiled_samples >= 50  -- suppress tiny cancer types
 ORDER BY frequency_pct DESC;
 ```
 
+### Variant: top-N most-mutated genes in a cohort (`top_mutated_genes_in_cohort`)
+
+When the user asks "what are the most-mutated genes in cohort X" instead of naming a specific gene, use this view. Mirrors cbioportal-backend's `StudyViewMapper.getMutatedGenes` with the same WES-aware per-gene denominator as the gene-frequency view.
+
+```sql
+SELECT *
+FROM top_mutated_genes_in_cohort(
+    preference = 'pan_cancer_tcga',
+    top_n      = 20
+);
+```
+
+Returns `(hugo_gene_symbol, altered_samples, profiled_samples, frequency_pct, total_mutation_events)`, sorted by `altered_samples DESC` then gene symbol ASC (matching the backend's tiebreaker). Per-gene `profiled_samples` correctly reflects which samples were assayed for that gene — for targeted-panel cohorts (`large_genomic_cohort` = msk_impact_50k_2026), the denominator is samples on a panel that includes the gene; for WES cohorts (`pan_cancer_tcga`), every gene gets the same WES-sample denominator.
+
+### Variant: Spearman correlation between two genes (`gene_pair_coexpression`)
+
+When the user asks whether two genes' expression (or copy number, methylation, etc.) is correlated in a study, use this view. Mirrors cbioportal-backend's `ClickhouseCoExpressionMapper.getCoExpressions`, simplified to the typical agent question of *one pair of genes* rather than one ref gene vs all others.
+
+```sql
+SELECT *
+FROM gene_pair_coexpression(
+    study         = 'brca_metabric',
+    gene_a        = 'TP53',
+    gene_b        = 'MYC',
+    profile_type  = 'mrna'
+);
+```
+
+Returns one row: `(gene_a, gene_b, profile_type, spearman_correlation, num_samples)`. `spearman_correlation` is in [−1, 1]; `NULL` when fewer than 3 valid paired samples.
+
+Discover available profile types for a study:
+
+```sql
+SELECT DISTINCT profile_type
+FROM genetic_alteration_derived
+WHERE cancer_study_identifier = 'brca_metabric'
+ORDER BY profile_type;
+```
+
+Common values: `mrna`, `mrna_median_Zscores`, `mrna_seq_v2_rsem`, `mrna_seq_v2_rsem_Zscores` for expression; `cna`, `linear_CNA`, `gistic` for copy number; `methylation_*` for methylation.
+
+> **Don't use this view to claim "co-occurrence of mutations".** Spearman correlation is for continuous values (expression, copy number). For mutation–mutation co-occurrence the agent should compute a 2×2 sample contingency table and run Fisher's exact / log odds-ratio — `gene_pair_coexpression` will silently return something close to 0 because the input is essentially two binary columns and Spearman is the wrong tool.
+
 ### Why this works
 - **`cancer_study_query_preferences` enforces a non-overlapping cohort.** Every shipped preference resolves to studies with no shared samples, so `COUNT(DISTINCT sample_unique_id)` doesn't double-count.
 - **`CANCER_TYPE` from `clinical_data_derived`, not `type_of_cancer_id` from `cancer_study`.** Multi-cancer-type studies (MSK-CHORD, MSK-IMPACT-50k, GENIE) carry `cancer_study.type_of_cancer_id = 'mixed'`; the per-sample diagnosis lives in the clinical data. Using the clinical attribute also works uniformly for single-cancer-type studies in the same cohort.

--- a/src/cbioportal_mcp/resources/mutation-frequency-guide.md
+++ b/src/cbioportal_mcp/resources/mutation-frequency-guide.md
@@ -62,7 +62,7 @@ ORDER BY frequency_pct DESC;
 
 Returns `(cancer_type, altered_samples, profiled_samples, frequency_pct)` for every cancer type with ≥ 50 profiled samples for the gene in the cohort. The recipe works identically whether the preference resolves to 1 study or 242.
 
-The view is defined in `sql/4-mutation-coverage-views.sql` and handles the WES-vs-named-panel split internally (see "Why this works" below). The agent should prefer this view for any "gene X across cancer types in cohort Y" question instead of writing the JOIN chain by hand.
+The view is defined in `sql/4-mutation-frequency-views.sql` and handles the WES-vs-named-panel split internally (see "Why this works" below). The agent should prefer this view for any "gene X across cancer types in cohort Y" question instead of writing the JOIN chain by hand.
 
 For variations the view doesn't cover (top-N most-mutated genes per cancer type, comparing two specific cancer types, single-study queries that need extra filters), drop down to the expanded CTE form below and adapt — but start from this CTE form, not a from-scratch JOIN chain that risks missing the WES branch:
 
@@ -137,7 +137,7 @@ Gene expression / copy-number correlation questions ("are TP53 and MYC expressio
 ### Why this works
 - **`cancer_study_query_preferences` enforces a non-overlapping cohort.** Every shipped preference resolves to studies with no shared samples, so `COUNT(DISTINCT sample_unique_id)` doesn't double-count.
 - **`CANCER_TYPE` from `clinical_data_derived`, not `type_of_cancer_id` from `cancer_study`.** Multi-cancer-type studies (MSK-CHORD, MSK-IMPACT-50k, GENIE) carry `cancer_study.type_of_cancer_id = 'mixed'`; the per-sample diagnosis lives in the clinical data. Using the clinical attribute also works uniformly for single-cancer-type studies in the same cohort.
-- **WES-aware profiled denominator.** Samples on a named panel are profiled for the genes listed in `gene_panel_list`; WES samples are profiled for *every* gene. `WES` is not in the `gene_panel` table at all, so the older recipe that joined through `gene_panel` / `gene_panel_list` silently dropped WES rows — producing >100% frequencies wherever WES studies contributed altered samples but no profiled samples. The two views in `sql/4-mutation-coverage-views.sql` (`mutation_panel_gene_coverage` and `mutation_wes_coverage`) encapsulate this split so every gene-frequency query gets the WES branch for free via the `UNION ALL` above.
+- **WES-aware profiled denominator.** Samples on a named panel are profiled for the genes listed in `gene_panel_list`; WES samples are profiled for *every* gene. `WES` is not in the `gene_panel` table at all, so the older recipe that joined through `gene_panel` / `gene_panel_list` silently dropped WES rows — producing >100% frequencies wherever WES studies contributed altered samples but no profiled samples. The two views in `sql/4-mutation-frequency-views.sql` (`mutation_panel_gene_coverage` and `mutation_wes_coverage`) encapsulate this split so every gene-frequency query gets the WES branch for free via the `UNION ALL` above.
 
 ### When to vary
 - **Top-N most-mutated genes per cancer type**: drop the `hugo_gene_symbol = '…'` filter and group by `(cancer_type, hugo_gene_symbol)`. Same CTEs.

--- a/src/cbioportal_mcp/resources/system-prompt.md
+++ b/src/cbioportal_mcp/resources/system-prompt.md
@@ -12,6 +12,7 @@ BEFORE ANSWERING ANY QUESTION, you MUST:
    - Clinical data questions: read `cbioportal://clinical-data-guide`
    - Sample/study filtering: read `cbioportal://sample-filtering-guide`
    - Treatment questions: read `cbioportal://treatment-guide`
+   - **Gene expression / copy-number / methylation / correlation between two genes**: read `cbioportal://gene-expression-guide`. This is the home for `genetic_alteration_derived` and the `gene_pair_coexpression` view. Don't try to answer expression-correlation questions through mutation-frequency tools.
    - General cBioPortal questions (history, features, data types, how to cite): read `cbioportal://faq-guide`
    - Cancer type disambiguation: call `search_oncotree(search_term)`
    - When unsure: read `cbioportal://common-pitfalls`

--- a/src/cbioportal_mcp/server.py
+++ b/src/cbioportal_mcp/server.py
@@ -232,6 +232,9 @@ def _faq_guide_text() -> str:
 def _statistical_tests_guide_text() -> str:
     return _load_resource("statistical-tests-guide.md")
 
+def _gene_expression_guide_text() -> str:
+    return _load_resource("gene-expression-guide.md")
+
 # --- MCP resources (decorator registers them) --------------------------------
 @mcp.resource("cbioportal://mutation-frequency-guide")
 def mutation_frequency_guide() -> str:
@@ -260,6 +263,10 @@ def faq_guide() -> str:
 @mcp.resource("cbioportal://statistical-tests-guide")
 def statistical_tests_guide() -> str:
     return _statistical_tests_guide_text()
+
+@mcp.resource("cbioportal://gene-expression-guide")
+def gene_expression_guide() -> str:
+    return _gene_expression_guide_text()
 
 
 @mcp.tool(
@@ -429,6 +436,10 @@ def list_guides() -> list[dict]:
             "description": "Statistical test selection guide — decision matrix for choosing Fisher's exact, Wilcoxon, chi-squared, t-test, ANOVA, etc. based on data type and group count"
         },
         {
+            "uri": "cbioportal://gene-expression-guide",
+            "description": "Gene expression / copy-number / methylation analysis. Covers genetic_alteration_derived, profile_type discovery, and the gene_pair_coexpression view for Spearman correlation between two genes"
+        },
+        {
             "uri": "cbioportal://study-guide/{study_id}",
             "description": "Dynamic study-specific guide - use get_study_guide(study_id) tool to generate"
         }
@@ -452,7 +463,8 @@ def read_guide(uri: str) -> str:
         "cbioportal://common-pitfalls": _common_pitfalls_guide_text(),
         "cbioportal://treatment-guide": _treatment_guide_text(),
         "cbioportal://faq-guide": _faq_guide_text(),
-        "cbioportal://statistical-tests-guide": _statistical_tests_guide_text()
+        "cbioportal://statistical-tests-guide": _statistical_tests_guide_text(),
+        "cbioportal://gene-expression-guide": _gene_expression_guide_text()
     }
 
     if uri not in resources:


### PR DESCRIPTION
Inspired by skimming `cbioportal-backend`'s ClickHouse MyBatis mappers — there are ~30 named queries already battle-tested by the frontend. Adding the two with highest agent leverage:

## `top_mutated_genes_in_cohort(preference, top_n)`

Mirrors `StudyViewMapper.getMutatedGenes`. Closes the "top-N most-mutated genes in cohort X" gap the gene-fixed frequency views don't cover (called out explicitly as a follow-up in #50).

Same WES-aware per-gene denominator as `gene_mutation_frequency_by_cancer_type`, but kept cheap at cohort scale by computing the WES sample count **once per cohort** (one number, since WES profiles every gene) and the named-panel sample count **per-gene** (only as many rows as there are panel-listed genes — not 20k × cohort_samples).

Verified live:

| `preference` | top 5 | Notes |
|---|---|---|
| `pan_cancer_tcga` | TP53 36.8%, TTN 30%, MUC16 19%, PIK3CA 13%, CSMD3 12.9% | Classic TCGA top — TTN/MUC16/CSMD3/RYR2/LRP1B are long-gene passenger artifacts |
| `large_genomic_cohort` (msk_impact_50k_2026) | TP53 45.2%, KRAS 16.4%, PIK3CA 14.1%, TERT 13.6%, APC 11.1% | Driver-heavy — IMPACT panel doesn't include long passengers |

## `gene_pair_coexpression(study, gene_a, gene_b, profile_type)`

Mirrors `ClickhouseCoExpressionMapper.getCoExpressions`, simplified to a pair lookup. The backend computes one ref gene vs all other genes for the coexpression page; here the agent asks about a specific pair like *"are TP53 and MYC correlated?"*.

Verified live (brca_metabric, profile_type='mrna'):

| gene_a | gene_b | spearman | n |
|---|---|---|---|
| TP53 | MYC | 0.118 | 1980 |
| ESR1 | PGR | 0.487 | 1980 |

The 0.487 ESR1↔PGR correlation is the textbook breast-cancer estrogen-receptor coregulation — sanity check passes.

Guide gains two `Variant:` sections under the canonical cohort recipe, plus a discovery query (`SELECT DISTINCT profile_type FROM genetic_alteration_derived WHERE cancer_study_identifier = …`) so the agent can find the right profile name (`mrna`, `mrna_median_Zscores`, `mrna_seq_v2_rsem_Zscores`, `linear_CNA`, `gistic`, `methylation_*`, etc.). One explicit warning is included: don't use `gene_pair_coexpression` for **mutation–mutation co-occurrence** — Spearman on essentially-binary inputs returns near-zero and the agent will misinterpret independence (see cBioPortal/cbioportal-navigator#43 for the real bug pattern). Mutation co-occurrence needs a 2×2 contingency table + Fisher's exact.

## Test plan

- [ ] Merge — image rebuild ships the updated guide.
- [ ] Apply `sql/4-mutation-coverage-views.sql` to the active LLM clone via `scripts/apply_sql.sh` (already done on `cbioportal_public_librechat_green` for verification — views are pure DDL).
- [ ] Roll the MCP pod so `read_guide` serves the updated guide.
- [ ] Smoke test agent answers for: "top 20 mutated genes in TCGA pan-cancer" (should hit `top_mutated_genes_in_cohort`); "is TP53 expression correlated with MYC in METABRIC" (should hit `gene_pair_coexpression(profile_type='mrna')`).

## Backend mappers as inventory

The `cBioPortal/cbioportal` repo has more ClickHouse mappers worth mining for future views — `getCnaGenes`, `getStructuralVariantGenes`, `getMutationCountsByType`, `getClinicalDataCountsByStudyViewFilter`, `getPatientTreatmentCounts`, `getGenomicDataBinCounts`. Filing as a tracking issue would keep this PR scoped to the two highest-leverage views and let the rest be picked up incrementally.