### PR TITLE
Make imaging / external-resource check fire on more triggers (closes #58)

### DIFF
--- a/src/cbioportal_mcp/resources/common-pitfalls.md
+++ b/src/cbioportal_mcp/resources/common-pitfalls.md
@@ -468,6 +468,61 @@ WHERE cs.cancer_study_identifier ILIKE '%htan%';
 
 **Key rule:** cBioPortal stores external resource links in `resource_sample`, `resource_patient`, `resource_study`, and `resource_definition` tables. Always check these before saying something is out of scope.
 
+#### ❌ Wrong: Generic "is there any imaging data?" → blanket refusal
+```
+User: "is there any imaging data?"
+Bot:  "No, cBioPortal does not contain imaging data such as CT scans, MRI
+       images, pathology slides, or other radiological/histological images.
+       cBioPortal focuses specifically on molecular genomic data..."
+```
+
+This is wrong: HTAN-loaded studies (`brca_hta9_htan_2022`, `crc_hta8_htan_2024`,
+`crc_hta11_htan_2021`, `ovary_geomx_gray_foundation_2024`, etc.) link to
+Minerva imaging viewers via `resource_sample`. The agent must verify
+absence by query, not by intuition about the database scope.
+
+#### ✅ Correct: Check `resource_definition` for imaging-type resources first
+```sql
+-- Step 1: Are there any imaging-related resource types defined at all?
+SELECT resource_id, display_name, description, resource_type
+FROM resource_definition
+WHERE lower(display_name)  ILIKE ANY ('%imag%', '%minerva%', '%viewer%',
+                                       '%histol%', '%pathol%', '%radiol%',
+                                       '%wsi%', '%slide%')
+   OR lower(description)   ILIKE ANY ('%imag%', '%minerva%', '%viewer%',
+                                       '%histol%', '%pathol%', '%radiol%')
+ORDER BY resource_type, display_name;
+
+-- Step 2: For each matched resource_id, find the studies that link to it
+--         and a sample URL so the user has something concrete to click.
+SELECT
+    rs.cancer_study_identifier,
+    rs.resource_id,
+    rd.display_name,
+    count(DISTINCT rs.sample_unique_id) AS samples_with_link,
+    any(rs.url) AS example_url
+FROM resource_sample rs
+JOIN resource_definition rd USING (resource_id)
+WHERE rs.resource_id IN (
+    SELECT resource_id FROM resource_definition
+    WHERE lower(display_name) ILIKE ANY ('%imag%','%minerva%','%viewer%',
+                                          '%histol%','%pathol%','%radiol%')
+)
+GROUP BY rs.cancer_study_identifier, rs.resource_id, rd.display_name
+ORDER BY samples_with_link DESC;
+```
+
+If step 1 returns rows: report them. The honest answer is *"cBioPortal
+doesn't host imaging files itself, but it links to external imaging
+viewers for some studies — here are the studies that have such links,
+and an example URL"*. If step 1 returns ZERO rows in this deployment,
+then "no imaging data" is a defensible answer for the current clone.
+
+Apply the same pattern for questions about whole-slide images (`%slide%`,
+`%wsi%`), pathology reports, methylation array IDATs, or any other
+non-tabular data type the user names: query `resource_definition` for
+matching keywords first, then `resource_*` for the actual links.
+
 ### 15. 🚨 HALLUCINATED TABLES OR COLUMNS
 
 #### ❌ Wrong: Querying tables or columns that don't exist

--- a/src/cbioportal_mcp/resources/system-prompt.md
+++ b/src/cbioportal_mcp/resources/system-prompt.md
@@ -13,6 +13,7 @@ BEFORE ANSWERING ANY QUESTION, you MUST:
    - Sample/study filtering: read `cbioportal://sample-filtering-guide`
    - Treatment questions: read `cbioportal://treatment-guide`
    - **Gene expression / copy-number / methylation / correlation between two genes**: read `cbioportal://gene-expression-guide`. This is the home for `genetic_alteration_derived` and the `gene_pair_coexpression` view. Don't try to answer expression-correlation questions through mutation-frequency tools.
+   - **Imaging / histology / pathology / radiology / WSI / slides / Minerva / viewer / external-resource questions**: STOP — do NOT answer "no, cBioPortal has no imaging data". cBioPortal stores links to external imaging/viewer/data-portal resources in `resource_sample`, `resource_patient`, `resource_study`, and `resource_definition` (e.g. HTAN studies link to Minerva viewers, some studies link to dbGaP / Synapse / etc.). Read `cbioportal://common-pitfalls` pitfall #14 and run the worked example queries against `resource_definition` + `resource_study` + `resource_sample` FIRST. Only say "no imaging" after confirming both `resource_definition` has no imaging-typed entries AND no `resource_sample` rows exist with image-related URLs.
    - General cBioPortal questions (history, features, data types, how to cite): read `cbioportal://faq-guide`
    - Cancer type disambiguation: call `search_oncotree(search_term)`
    - When unsure: read `cbioportal://common-pitfalls`
@@ -68,6 +69,8 @@ cBioPortal is a cancer genomics research database with data from published studi
 Note: General questions *about cBioPortal itself* (history, how to cite, data types, abbreviations) ARE in scope — read `cbioportal://faq-guide` to answer them.
 
 **IMPORTANT:** Before declaring something out of scope, ALWAYS check if the data exists in cBioPortal first. Specifically, check the `resource_sample`, `resource_patient`, `resource_study`, and `resource_definition` tables for external resource links. These tables contain URLs to external viewers and portals (e.g., Minerva viewer links for HTAN studies). Only say "out of scope" AFTER confirming no relevant data exists.
+
+> **Failure mode to avoid (real example from feedback):** user asked *"is there any imaging data?"* and the agent replied *"No, cBioPortal does not contain imaging data such as CT scans, MRI images, pathology slides..."* without ever querying `resource_definition`. cBioPortal DOES link to imaging via HTAN studies (Minerva viewer URLs in `resource_sample`). For any question mentioning imaging / histology / pathology / radiology / Minerva / viewer / WSI / slides / external portal, run the queries in `common-pitfalls` pitfall #14 BEFORE answering — see also the imaging-specific worked example there.
 
 For out-of-scope questions, respond: "This question is outside the scope of cBioPortal data. cBioPortal contains cancer genomics research data from published studies. I cannot provide general medical advice, drug safety information, or causal claims about cancer."
 


### PR DESCRIPTION
Closes #58.

## What broke

User asked *"is there any imaging data?"* and the agent replied *"No, cBioPortal does not contain imaging data such as CT scans, MRI images, pathology slides, or other radiological/histological images. cBioPortal focuses specifically on molecular genomic data..."* — without ever querying `resource_definition` or `resource_sample`. The HTAN-loaded studies (`brca_hta9_htan_2022`, `crc_hta8_htan_2024`, `crc_hta11_htan_2021`, `ovary_geomx_gray_foundation_2024`, ...) DO link to Minerva imaging viewers via `resource_sample`. Langfuse trace: [`44bce76710a74ecabd46e1d2757ee1b1`](https://us.cloud.langfuse.com/trace/44bce76710a74ecabd46e1d2757ee1b1).

The rule "before saying out-of-scope, check `resource_*` tables" already exists in `system-prompt.md` and as pitfall #14 in `common-pitfalls.md`. The agent only triggered it for the specific Minerva example the docs used, not for the broader "imaging" / "histology" / "pathology" shape of the question.

## Fix

### `system-prompt.md`

- New explicit routing entry under **Resource Reading Requirements**: imaging / histology / pathology / radiology / WSI / slides / Minerva / viewer / external-resource questions now trigger a mandatory `resource_*` lookup before any refusal. The list of keyword triggers is in-prompt so the agent can pattern-match without reading a separate guide first.
- Under the existing Out-of-Scope rule, a worked failure-mode call-out using the exact wording from this user feedback. The model sees "this is the wrong shape of answer for this kind of question" right next to the rule.

### `common-pitfalls.md` (pitfall #14)

- Adds a second worked example specifically for the generic *"is there any imaging data?"* shape. Existing Minerva-by-name example stays. The new one queries `resource_definition` first (display_name + description match against an explicit keyword list: `imag`, `minerva`, `viewer`, `histol`, `pathol`, `radiol`, `wsi`, `slide`), then joins to `resource_sample` for actual URLs and per-study sample counts. Documents what the honest answer shape looks like when matches DO exist: *"cBioPortal doesn't host imaging files itself, but it links to external imaging viewers for some studies — here are the studies and an example URL"*.

Documentation-only — no SQL or code changes.

## Test plan

- [ ] Merge → CI rebuilds `cbioportal/mcp:latest`.
- [ ] Roll the MCP pod so the updated guides reach `read_guide`.
- [ ] Re-ask "is there any imaging data?" on chat.cbioportal.org — expect the agent to run a `resource_definition` lookup before answering, and to surface HTAN/Minerva links if matches exist.
- [ ] Re-ask the broader shape: "are there any pathology slides?" / "is there histology?" / "any radiology?" — should also trigger the resource-table check.