### PR TITLE
Add StudyScope model and Keycloak role parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,20 @@ export CLICKHOUSE_SECURE=true  # or false for insecure connections
 export CLICKHOUSE_MCP_SERVER_TRANSPORT=stdio # or http or sse
 ```
 
+Study-level authorization configuration is present but not yet wired into query
+execution. Defaults preserve current development behavior until auth is enabled:
+
+```bash
+export CBIOPORTAL_AUTH_ENABLED=false
+export CBIOPORTAL_AUTH_REQUIRED=false
+export CBIOPORTAL_KEYCLOAK_CLIENT_ID=cbioportal
+export CBIOPORTAL_ALL_STUDIES_ROLE=cbioportal:ALL
+export CBIOPORTAL_DEFAULT_STUDIES=
+export CBIOPORTAL_CLICKHOUSE_ALLOWED_STUDIES_SETTING=cbioportal_allowed_studies
+export CBIOPORTAL_CLICKHOUSE_ALLOW_ALL_SETTING=cbioportal_allow_all
+export CBIOPORTAL_MCP_PROFILE=internal
+```
+
 ## Preparing the database
 
 **We strongly recommend pointing the MCP at a *separate* ClickHouse database, not your production cBioPortal database directly.** Two reasons:

--- a/src/cbioportal_mcp/authentication/__init__.py
+++ b/src/cbioportal_mcp/authentication/__init__.py
@@ -1,0 +1,13 @@
+"""Authentication and authorization helpers for cBioPortal MCP."""
+
+from cbioportal_mcp.authentication.study_scope import (
+    StudyScope,
+    is_valid_study_id,
+    parse_study_scope_from_claims,
+)
+
+__all__ = [
+    "StudyScope",
+    "is_valid_study_id",
+    "parse_study_scope_from_claims",
+]

--- a/src/cbioportal_mcp/authentication/study_scope.py
+++ b/src/cbioportal_mcp/authentication/study_scope.py
@@ -1,0 +1,113 @@
+"""Study-level authorization model and Keycloak role parsing."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any, Iterable, Mapping
+
+from cbioportal_mcp.env import McpConfig
+
+VALID_STUDY_ID_PATTERN = re.compile(r"^[a-zA-Z0-9_-]+$")
+
+
+@dataclass(frozen=True)
+class StudyScope:
+    """Authorized cBioPortal study scope for one request/user."""
+
+    allowed_studies: frozenset[str]
+    allow_all: bool = False
+    source: str = "unknown"
+
+    def __post_init__(self) -> None:
+        normalized = frozenset(_validate_study_id(study_id) for study_id in self.allowed_studies)
+        object.__setattr__(self, "allowed_studies", normalized)
+
+
+def is_valid_study_id(study_id: str) -> bool:
+    """Return True when a string matches the server's study-ID character set."""
+    return bool(study_id and VALID_STUDY_ID_PATTERN.fullmatch(study_id))
+
+
+def parse_study_scope_from_claims(
+    claims: Mapping[str, Any] | None, config: McpConfig
+) -> StudyScope:
+    """Parse a request's JWT claims into a study authorization scope.
+
+    Auth-disabled mode preserves current development behavior by granting all
+    studies. When auth is enabled, missing or empty roles result in no access
+    unless ``CBIOPORTAL_DEFAULT_STUDIES`` is explicitly configured.
+    """
+    if not config.cbioportal_auth_enabled:
+        return StudyScope(
+            allowed_studies=frozenset(),
+            allow_all=True,
+            source="auth_disabled",
+        )
+
+    default_studies = _parse_default_studies(config.cbioportal_default_studies)
+
+    if not claims:
+        return _default_or_empty_scope(
+            default_studies, source="default_studies" if default_studies else "no_claims"
+        )
+
+    roles = _extract_keycloak_roles(claims, config.cbioportal_keycloak_client_id)
+    if config.cbioportal_all_studies_role in roles:
+        return StudyScope(
+            allowed_studies=frozenset(),
+            allow_all=True,
+            source="keycloak_role",
+        )
+
+    allowed_studies = frozenset(role for role in roles if is_valid_study_id(role))
+    if allowed_studies:
+        return StudyScope(
+            allowed_studies=allowed_studies,
+            allow_all=False,
+            source="keycloak_role",
+        )
+
+    return _default_or_empty_scope(
+        default_studies, source="default_studies" if default_studies else "keycloak_role"
+    )
+
+
+def _validate_study_id(study_id: str) -> str:
+    if not is_valid_study_id(study_id):
+        raise ValueError(
+            f"Invalid study_id {study_id!r}. "
+            "Study IDs may only contain alphanumeric characters, underscores, and hyphens."
+        )
+    return study_id
+
+
+def _extract_keycloak_roles(claims: Mapping[str, Any], client_id: str) -> frozenset[str]:
+    resource_access = claims.get("resource_access")
+    if not isinstance(resource_access, Mapping):
+        return frozenset()
+
+    client_access = resource_access.get(client_id)
+    if not isinstance(client_access, Mapping):
+        return frozenset()
+
+    roles = client_access.get("roles")
+    if not isinstance(roles, Iterable) or isinstance(roles, (str, bytes)):
+        return frozenset()
+
+    return frozenset(role for role in roles if isinstance(role, str) and role)
+
+
+def _parse_default_studies(raw_default_studies: str) -> frozenset[str]:
+    studies = frozenset(study.strip() for study in raw_default_studies.split(",") if study.strip())
+    for study_id in studies:
+        _validate_study_id(study_id)
+    return studies
+
+
+def _default_or_empty_scope(default_studies: frozenset[str], source: str) -> StudyScope:
+    return StudyScope(
+        allowed_studies=default_studies,
+        allow_all=False,
+        source=source,
+    )

--- a/src/cbioportal_mcp/env.py
+++ b/src/cbioportal_mcp/env.py
@@ -1,8 +1,7 @@
 """Environment configuration for cBioPortal MCP server."""
 
-from dataclasses import dataclass
 import os
-from typing import Optional
+from dataclasses import dataclass
 from enum import Enum
 
 
@@ -76,6 +75,98 @@ class McpConfig:
         """
 
         return str(os.getenv("CLICKHOUSE_DATABASE", "cgds_public_2025_06_24"))
+
+    @property
+    def cbioportal_auth_enabled(self) -> bool:
+        """Whether cBioPortal study authorization is enabled.
+
+        Default: false
+        """
+        return _env_bool("CBIOPORTAL_AUTH_ENABLED", default=False)
+
+    @property
+    def cbioportal_auth_required(self) -> bool:
+        """Whether unauthenticated HTTP/SSE requests should fail closed.
+
+        Request enforcement is wired in a later authorization PR. This flag is
+        exposed now so scope parsing can distinguish required auth from
+        compatibility mode.
+
+        Default: false
+        """
+        return _env_bool("CBIOPORTAL_AUTH_REQUIRED", default=False)
+
+    @property
+    def cbioportal_keycloak_client_id(self) -> str:
+        """Get the Keycloak client ID containing cBioPortal study roles.
+
+        Default: "cbioportal"
+        """
+        return os.getenv("CBIOPORTAL_KEYCLOAK_CLIENT_ID", "cbioportal")
+
+    @property
+    def cbioportal_all_studies_role(self) -> str:
+        """Get the role value that grants unrestricted study access.
+
+        Default: "cbioportal:ALL"
+        """
+        return os.getenv("CBIOPORTAL_ALL_STUDIES_ROLE", "cbioportal:ALL")
+
+    @property
+    def cbioportal_default_studies(self) -> str:
+        """Get comma-separated fallback studies for unauthenticated/default users.
+
+        Empty by default. Parsing and validation happens in the study-scope
+        module because it shares the study-ID validation contract.
+        """
+        return os.getenv("CBIOPORTAL_DEFAULT_STUDIES", "")
+
+    @property
+    def cbioportal_clickhouse_allowed_studies_setting(self) -> str:
+        """Get the ClickHouse custom setting name for allowed studies.
+
+        Default: "cbioportal_allowed_studies"
+        """
+        return os.getenv(
+            "CBIOPORTAL_CLICKHOUSE_ALLOWED_STUDIES_SETTING",
+            "cbioportal_allowed_studies",
+        )
+
+    @property
+    def cbioportal_clickhouse_allow_all_setting(self) -> str:
+        """Get the ClickHouse custom setting name for unrestricted access.
+
+        Default: "cbioportal_allow_all"
+        """
+        return os.getenv(
+            "CBIOPORTAL_CLICKHOUSE_ALLOW_ALL_SETTING",
+            "cbioportal_allow_all",
+        )
+
+    @property
+    def cbioportal_mcp_profile(self) -> str:
+        """Get the MCP exposure profile.
+
+        Reserved for later public-mode hardening. Default: "internal".
+        """
+        return os.getenv("CBIOPORTAL_MCP_PROFILE", "internal")
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    """Parse a boolean environment variable using common true/false spellings."""
+    raw = os.getenv(name)
+    if raw is None or raw == "":
+        return default
+
+    value = raw.strip().lower()
+    if value in {"1", "true", "yes", "on"}:
+        return True
+    if value in {"0", "false", "no", "off"}:
+        return False
+    raise ValueError(
+        f"Invalid boolean value for {name}: {raw!r}. "
+        "Use one of: true/false, yes/no, on/off, 1/0."
+    )
 
 
 # Global instance placeholders for the singleton pattern

--- a/tests/authentication/test_study_scope.py
+++ b/tests/authentication/test_study_scope.py
@@ -1,0 +1,170 @@
+import pytest
+
+from cbioportal_mcp.authentication.study_scope import (
+    StudyScope,
+    is_valid_study_id,
+    parse_study_scope_from_claims,
+)
+from cbioportal_mcp.env import McpConfig
+
+
+def _claims(client_id: str = "cbioportal", roles: list[str] | None = None) -> dict:
+    return {
+        "resource_access": {
+            client_id: {
+                "roles": roles or [],
+            }
+        }
+    }
+
+
+@pytest.fixture(autouse=True)
+def clean_auth_env(monkeypatch):
+    env_vars = [
+        "CBIOPORTAL_AUTH_ENABLED",
+        "CBIOPORTAL_AUTH_REQUIRED",
+        "CBIOPORTAL_KEYCLOAK_CLIENT_ID",
+        "CBIOPORTAL_ALL_STUDIES_ROLE",
+        "CBIOPORTAL_DEFAULT_STUDIES",
+        "CBIOPORTAL_CLICKHOUSE_ALLOWED_STUDIES_SETTING",
+        "CBIOPORTAL_CLICKHOUSE_ALLOW_ALL_SETTING",
+        "CBIOPORTAL_MCP_PROFILE",
+    ]
+    for env_var in env_vars:
+        monkeypatch.delenv(env_var, raising=False)
+
+
+def test_no_claims_auth_disabled_allows_all():
+    scope = parse_study_scope_from_claims(None, McpConfig())
+
+    assert scope.allow_all is True
+    assert scope.allowed_studies == frozenset()
+    assert scope.source == "auth_disabled"
+
+
+def test_auth_disabled_does_not_validate_unused_default_studies(monkeypatch):
+    monkeypatch.setenv("CBIOPORTAL_DEFAULT_STUDIES", "bad study")
+
+    scope = parse_study_scope_from_claims(None, McpConfig())
+
+    assert scope.allow_all is True
+    assert scope.source == "auth_disabled"
+
+
+def test_no_claims_auth_required_has_no_access(monkeypatch):
+    monkeypatch.setenv("CBIOPORTAL_AUTH_ENABLED", "true")
+    monkeypatch.setenv("CBIOPORTAL_AUTH_REQUIRED", "true")
+
+    scope = parse_study_scope_from_claims(None, McpConfig())
+
+    assert scope.allow_all is False
+    assert scope.allowed_studies == frozenset()
+    assert scope.source == "no_claims"
+
+
+def test_valid_study_roles(monkeypatch):
+    monkeypatch.setenv("CBIOPORTAL_AUTH_ENABLED", "true")
+
+    scope = parse_study_scope_from_claims(
+        _claims(roles=["brca_tcga", "luad-tcga", "Study123"]),
+        McpConfig(),
+    )
+
+    assert scope.allow_all is False
+    assert scope.allowed_studies == frozenset({"brca_tcga", "luad-tcga", "Study123"})
+    assert scope.source == "keycloak_role"
+
+
+def test_invalid_study_role_strings_are_ignored(monkeypatch):
+    monkeypatch.setenv("CBIOPORTAL_AUTH_ENABLED", "true")
+
+    scope = parse_study_scope_from_claims(
+        _claims(roles=["brca_tcga", "bad study", "bad;study", "", "../bad"]),
+        McpConfig(),
+    )
+
+    assert scope.allowed_studies == frozenset({"brca_tcga"})
+
+
+def test_duplicate_roles_are_deduplicated(monkeypatch):
+    monkeypatch.setenv("CBIOPORTAL_AUTH_ENABLED", "true")
+
+    scope = parse_study_scope_from_claims(
+        _claims(roles=["brca_tcga", "brca_tcga"]),
+        McpConfig(),
+    )
+
+    assert scope.allowed_studies == frozenset({"brca_tcga"})
+
+
+def test_all_studies_role_allows_all(monkeypatch):
+    monkeypatch.setenv("CBIOPORTAL_AUTH_ENABLED", "true")
+
+    scope = parse_study_scope_from_claims(
+        _claims(roles=["brca_tcga", "cbioportal:ALL"]),
+        McpConfig(),
+    )
+
+    assert scope.allow_all is True
+    assert scope.allowed_studies == frozenset()
+    assert scope.source == "keycloak_role"
+
+
+def test_roles_under_non_default_client_id(monkeypatch):
+    monkeypatch.setenv("CBIOPORTAL_AUTH_ENABLED", "true")
+    monkeypatch.setenv("CBIOPORTAL_KEYCLOAK_CLIENT_ID", "custom-client")
+
+    scope = parse_study_scope_from_claims(
+        _claims(client_id="custom-client", roles=["brca_tcga"]),
+        McpConfig(),
+    )
+
+    assert scope.allowed_studies == frozenset({"brca_tcga"})
+
+
+def test_roles_under_wrong_client_id_are_ignored(monkeypatch):
+    monkeypatch.setenv("CBIOPORTAL_AUTH_ENABLED", "true")
+    monkeypatch.setenv("CBIOPORTAL_KEYCLOAK_CLIENT_ID", "custom-client")
+
+    scope = parse_study_scope_from_claims(
+        _claims(client_id="cbioportal", roles=["brca_tcga"]),
+        McpConfig(),
+    )
+
+    assert scope.allow_all is False
+    assert scope.allowed_studies == frozenset()
+
+
+def test_configured_default_studies(monkeypatch):
+    monkeypatch.setenv("CBIOPORTAL_AUTH_ENABLED", "true")
+    monkeypatch.setenv("CBIOPORTAL_DEFAULT_STUDIES", "brca_tcga, luad-tcga")
+
+    scope = parse_study_scope_from_claims(None, McpConfig())
+
+    assert scope.allow_all is False
+    assert scope.allowed_studies == frozenset({"brca_tcga", "luad-tcga"})
+    assert scope.source == "default_studies"
+
+
+def test_empty_access_means_no_access(monkeypatch):
+    monkeypatch.setenv("CBIOPORTAL_AUTH_ENABLED", "true")
+
+    scope = parse_study_scope_from_claims(_claims(roles=[]), McpConfig())
+
+    assert scope.allow_all is False
+    assert scope.allowed_studies == frozenset()
+    assert scope.source == "keycloak_role"
+
+
+def test_study_scope_rejects_invalid_study_ids():
+    with pytest.raises(ValueError, match="Invalid study_id"):
+        StudyScope(allowed_studies=frozenset({"brca_tcga", "bad study"}))
+
+
+def test_study_id_validation_matches_expected_character_set():
+    assert is_valid_study_id("brca_tcga")
+    assert is_valid_study_id("luad-tcga")
+    assert is_valid_study_id("Study123")
+    assert not is_valid_study_id("bad study")
+    assert not is_valid_study_id("bad.study")
+    assert not is_valid_study_id("")

--- a/tests/test_env_auth_config.py
+++ b/tests/test_env_auth_config.py
@@ -1,0 +1,60 @@
+import pytest
+
+from cbioportal_mcp.env import McpConfig
+
+
+@pytest.fixture(autouse=True)
+def clean_auth_env(monkeypatch):
+    for env_var in [
+        "CBIOPORTAL_AUTH_ENABLED",
+        "CBIOPORTAL_AUTH_REQUIRED",
+        "CBIOPORTAL_KEYCLOAK_CLIENT_ID",
+        "CBIOPORTAL_ALL_STUDIES_ROLE",
+        "CBIOPORTAL_DEFAULT_STUDIES",
+        "CBIOPORTAL_CLICKHOUSE_ALLOWED_STUDIES_SETTING",
+        "CBIOPORTAL_CLICKHOUSE_ALLOW_ALL_SETTING",
+        "CBIOPORTAL_MCP_PROFILE",
+    ]:
+        monkeypatch.delenv(env_var, raising=False)
+
+
+def test_auth_config_defaults_are_compatible():
+    config = McpConfig()
+
+    assert config.cbioportal_auth_enabled is False
+    assert config.cbioportal_auth_required is False
+    assert config.cbioportal_keycloak_client_id == "cbioportal"
+    assert config.cbioportal_all_studies_role == "cbioportal:ALL"
+    assert config.cbioportal_default_studies == ""
+    assert config.cbioportal_clickhouse_allowed_studies_setting == "cbioportal_allowed_studies"
+    assert config.cbioportal_clickhouse_allow_all_setting == "cbioportal_allow_all"
+    assert config.cbioportal_mcp_profile == "internal"
+
+
+def test_auth_config_reads_env(monkeypatch):
+    monkeypatch.setenv("CBIOPORTAL_AUTH_ENABLED", "yes")
+    monkeypatch.setenv("CBIOPORTAL_AUTH_REQUIRED", "1")
+    monkeypatch.setenv("CBIOPORTAL_KEYCLOAK_CLIENT_ID", "custom-client")
+    monkeypatch.setenv("CBIOPORTAL_ALL_STUDIES_ROLE", "all-studies")
+    monkeypatch.setenv("CBIOPORTAL_DEFAULT_STUDIES", "brca_tcga")
+    monkeypatch.setenv("CBIOPORTAL_CLICKHOUSE_ALLOWED_STUDIES_SETTING", "allowed")
+    monkeypatch.setenv("CBIOPORTAL_CLICKHOUSE_ALLOW_ALL_SETTING", "allow_all")
+    monkeypatch.setenv("CBIOPORTAL_MCP_PROFILE", "authenticated")
+
+    config = McpConfig()
+
+    assert config.cbioportal_auth_enabled is True
+    assert config.cbioportal_auth_required is True
+    assert config.cbioportal_keycloak_client_id == "custom-client"
+    assert config.cbioportal_all_studies_role == "all-studies"
+    assert config.cbioportal_default_studies == "brca_tcga"
+    assert config.cbioportal_clickhouse_allowed_studies_setting == "allowed"
+    assert config.cbioportal_clickhouse_allow_all_setting == "allow_all"
+    assert config.cbioportal_mcp_profile == "authenticated"
+
+
+def test_invalid_bool_env_fails_closed(monkeypatch):
+    monkeypatch.setenv("CBIOPORTAL_AUTH_ENABLED", "definitely")
+
+    with pytest.raises(ValueError, match="Invalid boolean value"):
+        _ = McpConfig().cbioportal_auth_enabled


### PR DESCRIPTION
## Summary
- Add PR 1 study authorization configuration flags with compatibility-preserving defaults.
- Add a frozen StudyScope model and isolated Keycloak resource_access role parser.
- Support cbioportal:ALL, configurable Keycloak client ID, explicit default studies, duplicate-role deduping, and safe study ID validation.
- Document the new env vars while noting that query execution is not wired yet.

## Test plan
- .venv/bin/pytest
- .venv/bin/black --check src/cbioportal_mcp/env.py src/cbioportal_mcp/authentication/__init__.py src/cbioportal_mcp/authentication/study_scope.py tests/authentication/test_study_scope.py tests/test_env_auth_config.py
- .venv/bin/ruff check src/cbioportal_mcp/env.py src/cbioportal_mcp/authentication/__init__.py src/cbioportal_mcp/authentication/study_scope.py tests/authentication/test_study_scope.py tests/test_env_auth_config.py
- git diff --check

## Notes
- This intentionally does not change runtime query behavior, FastMCP request handling, or ClickHouse policy setup.
- Repo-wide ruff/black still report pre-existing unrelated issues in files such as server.py and scripts/update_oncotree.py; changed Python files pass.