### PR TITLE
Guard against silent query rewrites and fabricated statistics (#66, #68)

### DIFF
--- a/src/cbioportal_mcp/resources/common-pitfalls.md
+++ b/src/cbioportal_mcp/resources/common-pitfalls.md
@@ -494,6 +494,42 @@ WHERE attribute_name = 'TUMOR_GRADE' AND cancer_study_identifier = 'brca_tcga';
 
 **Key rule:** Never assume a table or column exists. Always check with `clickhouse_list_tables` and `clickhouse_list_table_columns` first.
 
+### 16. 🚨 SILENT QUERY SUBSTITUTION ("did you mean...")
+
+When the user's wording differs from canonical terminology (e.g. "V600V" looks like "V600E" with a typo, or "point mutation" sounds like "missense"), it is forbidden to silently rewrite the question and answer the rewritten version. Doing so produces an answer that looks confident but is for a different question — the user cannot tell what was changed.
+
+#### ❌ Wrong: silently substitute
+
+> User: *"Find patients in colorectal cancer with the V600V alteration in BRAF"*
+> Agent: *(internally treats this as V600E)* "I found 412 samples with BRAF V600E in colorectal studies..."
+
+> User: *"What is the most prevalent TP53 mutation in uterine cancer that is not a point mutation?"*
+> Agent: *(internally treats "point mutation" = "missense", silently excludes only missense)* "The most prevalent non-missense TP53 mutation is..."
+
+#### ✅ Correct: answer the literal question, flag any normalization
+
+For an unusual-looking variant the user may have typed deliberately:
+- Query for what was asked, literally.
+- If 0 rows come back, **explain *why* zero is the expected answer** before suggesting a likely-intended alternative. For synonymous variants (e.g. BRAF V600V, TP53 R175R), the explanation is: *cBioPortal's mutation tables filter out synonymous (silent) variants in most studies, so 0 hits means "filtered upstream", not "no such variant exists in any patient"*. Then ask: *"Did you mean V600E (the canonical activating variant)? Or would you like me to look for V600V in the studies that do retain synonymous calls?"*
+- If the wording is ambiguous (e.g. "point mutation"), ask the user which definition they meant before querying — do not pick one silently.
+
+#### Mutation-type terminology mapping (use this to disambiguate)
+
+| User says | Canonical definition | `mutation_type` filter |
+|---|---|---|
+| "point mutation" | Any SNV (single-nucleotide variant) — includes missense, nonsense, synonymous, splice-site SNVs | `mutation_type IN ('Missense_Mutation','Nonsense_Mutation','Silent','Splice_Site')` — **but ask the user to confirm scope first** |
+| "missense" | Single amino-acid substitution that changes the protein | `mutation_type = 'Missense_Mutation'` |
+| "nonsense" / "stop-gain" | Premature stop codon | `mutation_type = 'Nonsense_Mutation'` |
+| "synonymous" / "silent" | Nucleotide change with no amino-acid change | `mutation_type = 'Silent'` (**often filtered out of public datasets** — see below) |
+| "splice site" | Mutation in canonical splice acceptor/donor | `mutation_type = 'Splice_Site'` |
+| "frameshift" | Indel changing reading frame | `mutation_type IN ('Frame_Shift_Ins','Frame_Shift_Del')` |
+| "indel" / "in-frame" | In-frame insertion or deletion | `mutation_type IN ('In_Frame_Ins','In_Frame_Del')` |
+| "truncating" | Anything that disrupts the protein early | `mutation_type IN ('Nonsense_Mutation','Frame_Shift_Ins','Frame_Shift_Del','Splice_Site','Nonstop_Mutation')` |
+
+**Synonymous-variant filter.** Most cBioPortal studies drop `Silent` calls during the MAF/import pipeline because they're not biologically interesting and not annotated. A literal query for a synonymous variant (e.g. BRAF V600V) will return 0 rows from almost every study — the correct answer is *"filtered out of the dataset"*, not *"does not exist"*.
+
+**Promoter mutations.** TERT promoter variants (C228T, C250T) are *not* missense — they sit in the 5' UTR/promoter. Don't search for them with a missense filter; use `mutation_variant LIKE '%promoter%'` or `Start_Position` ranges. See `mutation-frequency-guide.md` for the canonical pattern.
+
 ## Best Practices Summary
 
 1. **Always use gene-specific denominators** for mutation frequencies
@@ -513,7 +549,7 @@ WHERE attribute_name = 'TUMOR_GRADE' AND cancer_study_identifier = 'brca_tcga';
 15. **Check resource tables before saying "out of scope"** — `resource_sample`, `resource_patient`, `resource_study`, `resource_definition` may have external links
 16. **Always verify schema** — never assume tables or columns exist without checking first
 17. **Never fabricate OncoKB/driver annotations** — check for driver columns first
-18. **Check resource tables before saying "out of scope"** — `resource_sample`, `resource_patient`, `resource_study`, `resource_definition` may have external links
+18. **Never silently rewrite the user's query** — if "point mutation" or "V600V" is ambiguous or unusual, surface the normalization or ask, don't substitute. See pitfall #16.
 
 ## Validation Checklist
 
@@ -531,3 +567,4 @@ Before trusting your results, ask:
 - [ ] Did I avoid fabricating OncoKB/driver annotations without checking driver columns first?
 - [ ] Before saying "out of scope", did I check `resource_sample`, `resource_patient`, `resource_study`, and `resource_definition` for external links?
 - [ ] Did I verify all tables and columns exist before querying them?
+- [ ] Did I answer the literal question, or did I silently rewrite it? If I normalized a term ("point mutation" → SNV set, "V600V" → V600E), did I surface that to the user?

--- a/src/cbioportal_mcp/resources/statistical-tests-guide.md
+++ b/src/cbioportal_mcp/resources/statistical-tests-guide.md
@@ -5,6 +5,28 @@ Purpose
 -------
 This guide ensures the correct statistical test is selected before performing any group comparison, matching cBioPortal's own Group Comparison defaults.
 
+HARD RULES — NEVER FABRICATE A STATISTIC
+----------------------------------------
+ClickHouse cannot run statistical tests. The agent therefore must NEVER produce a derived statistic that is not a literal column value from a SQL result. Specifically:
+
+1. **Never invent a p-value.** Not "p < 0.001", not "p ≈ 0.05", not any p-value. If the user asks "what is the p-value?", the answer is *"I can't compute that — here is the 2x2 contingency table (or group statistics). Run it in cBioPortal's Group Comparison tab, in R with `fisher.test(...)` / `wilcox.test(...)`, or in Python with `scipy.stats.fisher_exact(...)` / `mannwhitneyu(...)`."*
+2. **Never claim mutual exclusivity (or co-occurrence) from a contingency table alone.** A 2x2 table is not a test. The shape "altered/not altered × group A/group B" needs Fisher's exact + a defined direction (odds ratio < 1 with significant p). Without that test, the agent presents the table and stops.
+3. **Never report a "median" that came from `AVG(...)` or any non-median aggregate.** "Median" and "mean" are different statistics; for skewed clinical distributions (especially survival) they differ substantially. Use ClickHouse's `quantile(0.5)(...)` for actual median, and label arithmetic averages as "mean", never "median".
+4. **Never report a hazard ratio, odds ratio, risk ratio, or relative risk** that wasn't computed by an external tool. These require regression / model fitting that ClickHouse does not do.
+5. **Never report median overall survival from `AVG(OS_MONTHS)` or even `quantile(0.5)(OS_MONTHS)`.** Median OS requires Kaplan-Meier estimation, which handles censoring (`OS_STATUS = 0:LIVING` means the event hasn't happened yet). Naive medians/means over `OS_MONTHS` ignore censoring and are systematically wrong. The correct handoff: return the raw `(OS_MONTHS, OS_STATUS)` pairs (or descriptive counts: N events, N censored, follow-up range) and tell the user to run KM in R (`survival::survfit`) or Python (`lifelines.KaplanMeierFitter`), or use cBioPortal's Survival comparison.
+
+If asked to do any of (1)–(5), respond with the appropriate handoff template from the "Approved Response Templates" section below — do not produce the number.
+
+Ambiguous-Term Clarification (before any analysis)
+--------------------------------------------------
+If the user's question uses an ambiguous term, ask before computing anything. Examples:
+
+- **"aggressive"** → could mean shorter overall survival, higher metastasis rate, higher grade/stage, higher TMB, or specific molecular features. Ask which definition before any query. Do NOT silently equate "aggressive" with "lower OS".
+- **"better outcome" / "worse outcome"** → same problem. Ask: OS? PFS? DFS? Response rate?
+- **"more common"** → frequency among what denominator? Profiled samples for that gene? All samples in the study? Patients (one count per patient) or samples (multiple per patient)?
+
+State the chosen interpretation explicitly before computing, so the user can correct you before you run the query.
+
 MANDATORY: Pre-Analysis Checklist
 ----------------------------------
 Before running any statistical comparison, determine:
@@ -97,6 +119,46 @@ GROUP BY cancer_study_identifier
 ```
 
 Then state: "This is a 2-group alteration comparison. The appropriate test is Fisher's exact test (two-tailed). Here is the 2x2 contingency table — you can compute the p-value in cBioPortal's Group Comparison tab, or in R with `fisher.test(matrix(c(...), nrow=2))`."
+
+Approved Response Templates
+---------------------------
+
+### When asked for a p-value
+> "ClickHouse can't compute statistical tests. Here is the 2x2 contingency table:
+>
+> | | altered | unaltered |
+> |---|---|---|
+> | Group A | a | b |
+> | Group B | c | d |
+>
+> The appropriate test is **Fisher's exact (two-tailed)** because [reason]. You can compute the p-value in:
+> - **cBioPortal's Group Comparison tab** (recommended — uses the same defaults)
+> - **R:** `fisher.test(matrix(c(a, b, c, d), nrow=2))`
+> - **Python:** `from scipy.stats import fisher_exact; fisher_exact([[a, b], [c, d]])`"
+
+### When asked about mutual exclusivity / co-occurrence
+> "I can show the contingency counts, but mutual exclusivity requires Fisher's exact (with odds ratio < 1) which I can't compute. Here are the counts: [table]. Run them through cBioPortal's Mutual Exclusivity tab or the R/Python snippets above. Looking at the raw counts alone — without the test — would be guessing."
+
+### When asked for median overall survival
+> "Median OS requires Kaplan-Meier estimation because survival data is censored — patients still alive at last follow-up have not yet experienced the event, and a naive `AVG()` or `quantile(0.5)` over `OS_MONTHS` ignores that. Here is the summary for your cohort:
+> - N total patients: ...
+> - N events (OS_STATUS = 1:DECEASED): ...
+> - N censored (OS_STATUS = 0:LIVING): ...
+> - Follow-up range: min ... – max ... months
+>
+> Run KM in R (`survival::survfit(Surv(OS_MONTHS, OS_STATUS==\"1:DECEASED\") ~ group, data=...)`), Python (`lifelines.KaplanMeierFitter`), or cBioPortal's Survival comparison."
+
+### When asked to compare "aggressiveness" / "outcome" between cohorts
+> "'Aggressive' could mean shorter OS, higher metastasis rate, higher grade/stage, higher TMB, or specific molecular features. Which would you like to compare? I'll pull the raw values and tell you which test applies."
+
+### Forbidden Shapes (do not produce these outputs)
+
+- ❌ "Median overall survival is 24.3 months." (where the number came from `AVG()` or even raw `quantile`)
+- ❌ "These mutations are mutually exclusive (p < 0.001)." (no test was run)
+- ❌ "KRAS G12C is more aggressive than G12D (median OS 18 vs 25 months)." (KM not run, "aggressive" not clarified)
+- ❌ "Hazard ratio for EGFR-mutant vs wild-type LUAD is 0.67."  (regression not run)
+- ❌ "The p-value is approximately 0.03." (no test was run)
+- ❌ "Based on the contingency table, there is significant enrichment." (no test was run)
 
 Common Pitfalls
 ---------------

--- a/src/cbioportal_mcp/resources/system-prompt.md
+++ b/src/cbioportal_mcp/resources/system-prompt.md
@@ -9,6 +9,8 @@ BEFORE ANSWERING ANY QUESTION, you MUST:
 2. Call `read_guide(uri)` to read the relevant guide(s) for the query type:
    - Mutation frequency questions: read `cbioportal://mutation-frequency-guide`
      - **"Across cancer types" / "by cancer type" / "in different cancers"**: jump to the Cross-Cancer-Type Mutation Frequency section of that guide. There is one canonical recipe (single multi-cancer cohort + per-sample `CANCER_TYPE` from `clinical_data_derived`). Do not invent your own cross-study aggregation.
+     - **Mutation-type terminology in the question ("point mutation", "synonymous", "silent", "missense", "truncating", "promoter") OR a request that looks like a typo (e.g. "V600V" — which is the synonymous variant, not a typo for V600E)**: read `cbioportal://common-pitfalls` pitfall #16 BEFORE querying. There is a terminology mapping table and a hard rule against silently rewriting the user's question. Synonymous variants are filtered out of most cBioPortal studies — "0 hits" must be explained, not just reported.
+   - **Group comparison, p-value, mutual exclusivity, co-occurrence, hazard ratio, median survival, "aggressive"/"better outcome" questions**: read `cbioportal://statistical-tests-guide`. Pay attention to the **HARD RULES** at the top — ClickHouse cannot run tests, and you must never invent a p-value, fabricate a "median" from `AVG()`, or report median OS without Kaplan-Meier. Use the Approved Response Templates to hand off to cBioPortal Group Comparison / R / Python.
    - Clinical data questions: read `cbioportal://clinical-data-guide`
    - Sample/study filtering: read `cbioportal://sample-filtering-guide`
    - Treatment questions: read `cbioportal://treatment-guide`
@@ -40,12 +42,16 @@ Use the guides for full details; this is a quick reminder:
 
 ## Statistical Analysis
 Before performing any group comparison or statistical test:
-1. ALWAYS read the statistical-tests-guide first: call `read_guide("cbioportal://statistical-tests-guide")`
+1. ALWAYS read the statistical-tests-guide first: call `read_guide("cbioportal://statistical-tests-guide")` — pay particular attention to the **HARD RULES — NEVER FABRICATE A STATISTIC** section at the top
 2. Identify the data type (categorical vs. continuous) and number of groups
 3. Select the appropriate test per the guide's decision matrix — match cBioPortal's Group Comparison defaults
 4. State the chosen test and the rationale before presenting results
 5. ClickHouse cannot compute statistical tests directly — present the summary data (contingency table or group statistics) and recommend the user run the test in R, Python, or cBioPortal's Group Comparison tab
 6. Warn about multiple testing when comparing many genes or attributes simultaneously
+
+**Hard rule — never invent a derived statistic.** Any p-value, hazard ratio, odds ratio, "median" reported from non-median aggregates, mutual-exclusivity / co-occurrence claim, or median overall survival you produce that wasn't computed by an external statistical tool is a fabrication. If a user asks for one, return the underlying summary data (contingency table, raw `(OS_MONTHS, OS_STATUS)` pairs, group N/mean/median) and a one-line handoff to cBioPortal Group Comparison / R / Python — see the guide's "Approved Response Templates". Specifically: median OS requires Kaplan-Meier (handles censoring); `AVG(OS_MONTHS)` is wrong, and even `quantile(0.5)(OS_MONTHS)` is wrong because it ignores censoring.
+
+**Hard rule — never silently rewrite the user's query.** If the wording is ambiguous ("point mutation", "aggressive", "better outcome") or looks like a typo ("V600V" might be V600E), STOP. Either ask the user which definition they meant, or answer the literal question and surface any normalization you applied. Read `cbioportal://common-pitfalls` pitfall #16 — silent substitution is forbidden because the user cannot tell what was changed. For mutation-type terminology specifically: "point mutation" is NOT a synonym for "missense" (point mutation = any SNV, including synonymous/nonsense/splice); "V600V" is the synonymous variant (filtered out of most cBioPortal studies), not a typo for V600E.
 
 ## Scope — What You CAN Answer
 


### PR DESCRIPTION
## Summary

Addresses two related failure modes observed on beta (cBioPortalChatBeta) over the last week:

- **#66** — agent silently rewrites the user's query: `V600V` answered as `V600E`; "point mutation" answered as "missense".
- **#68** — agent invents statistics: median reported from `AVG()`; mutual exclusivity asserted from a contingency table alone; p-values fabricated then admitted to be made up.

The fix is purely in the guides the agent reads at runtime — no code changes.

### Changes

- `common-pitfalls.md` **pitfall #16 — Silent Query Substitution**: explicit rule against silent rewrites, plus a mutation-type terminology table (`point mutation`, `missense`, `nonsense`, `synonymous`/`silent`, `truncating`, `splice site`, `frameshift`, `indel`, `promoter`) mapped to the canonical definition and the correct `mutation_type` filter. Also explains the synonymous-variant filtering in the import pipeline so "0 hits for V600V" gets the right explanation ("filtered upstream", not "doesn't exist").

- `statistical-tests-guide.md` **new HARD RULES block at the top**:
  1. Never invent a p-value
  2. Never claim mutual exclusivity / co-occurrence from a contingency table alone
  3. Never report "median" computed from `AVG()` (or any non-median aggregate)
  4. Never report a hazard ratio, odds ratio, risk ratio
  5. Never report median OS from `AVG(OS_MONTHS)` or even `quantile(0.5)(OS_MONTHS)` — needs Kaplan-Meier because of censoring

  Plus an **Ambiguous-Term Clarification** section (clarify "aggressive" / "better outcome" / "more common" before computing), **Approved Response Templates** (for p-value, mutual exclusivity, median OS, aggressiveness handoffs), and a **Forbidden Shapes** list with the exact failure cases from the feedback.

- `system-prompt.md`: two new hard-rule paragraphs (never invent a derived statistic; never silently rewrite the user's query), plus routing entries for mutation-type terminology and statistical-test triggers so the relevant guides actually get read before the agent answers.

### What this does NOT fix

- The agent's tendency to over-iterate / use more tools per turn (separate cost-and-latency regression flagged in beta v9; needs its own investigation).
- The other beta tickets (#65 TERT promoter, #67 over-interpretation, #69 out-of-scope drift, #70 sample double-counting) — separate PRs.

## Test plan

- [ ] Beta agent gets the new guide content via the next image build and answers Guizela's test prompts without silent substitution:
  - "Find patients in colorectal cancer with the V600V alteration in BRAF" → literal query + synonymous-filter explanation, optionally followed by an "or did you mean V600E?" question.
  - "What is the most prevalent TP53 mutation in uterine cancer that is not a point mutation?" → clarification request before running the query.
- [ ] Beta agent declines to produce a p-value / median OS / mutual-exclusivity claim without an external test, instead returning the summary data + handoff template:
  - "Is KRAS G12C more aggressive than G12D?" → clarification on "aggressive", then if survival is chosen, returns (N events, N censored, follow-up range) + KM handoff.
  - "Give me a contingency table with EGFR/KRAS in lung cancer" → returns the table only; refuses to assert mutual exclusivity.
  - "What's the p-value?" → returns the handoff template, does not produce a number.

Closes #66
Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)