### PR TITLE
feat: add Datadog LLM Observability via ddtrace

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "clickhouse-driver>=0.2.0",
     "opentelemetry-sdk>=1.27.0",
     "opentelemetry-exporter-otlp-proto-http>=1.27.0",
+    "ddtrace",
 ]
 
 [project.optional-dependencies]

--- a/src/cbioportal_mcp/server.py
+++ b/src/cbioportal_mcp/server.py
@@ -1,6 +1,19 @@
 #!/usr/bin/env python3
 """cBioPortal MCP Server - FastMCP implementation."""
 
+import os
+
+from ddtrace.llmobs import LLMObs
+
+_dd_api_key = os.getenv("DD_API_KEY")
+if _dd_api_key:
+    LLMObs.enable(
+        ml_app=os.getenv("DD_LLMOBS_ML_APP", "cbioportal-mcp"),
+        api_key=_dd_api_key,
+        site=os.getenv("DD_SITE", "datadoghq.com"),
+        agentless_enabled=True,
+    )
+
 import json
 import logging
 import re


### PR DESCRIPTION
## Summary
- Adds `ddtrace` dependency for Datadog LLM Observability (LLMObs)
- Initializes `LLMObs.enable` at module load time in `server.py`, before all other imports, using agentless mode
- Feature is opt-in: only activates when `DD_API_KEY` is present in the environment — server starts normally without it

## Configuration
All settings are sourced from environment variables for K8s secret injection:

| Env var | Purpose | Default |
|---|---|---|
| `DD_API_KEY` | Enables LLM Observability (required to activate) | — |
| `DD_LLMOBS_ML_APP` | App name in LLM Observability Explorer | `cbioportal-mcp` |
| `DD_SITE` | Datadog site region | `datadoghq.com` |

No Datadog agent sidecar required — agentless mode sends traces directly to Datadog's ingest API. The existing OpenTelemetry/OTLP tracing pipeline is unaffected.

## Test plan
- [ ] Deploy with `DD_API_KEY` set as a K8s secret and confirm traces appear at https://app.datadoghq.com/llm/traces?query=@ml_app:cbioportal-mcp
- [ ] Confirm server starts normally without `DD_API_KEY` set (LLMObs silently skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)