### PR TITLE
Add CLICKHOUSE_MCP_HTTP_PATH env var for sub-path mount

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ export CLICKHOUSE_PASSWORD=your-password
 export CLICKHOUSE_DATABASE=your-cbioportal-database  # see "Preparing the database" below
 export CLICKHOUSE_SECURE=true  # or false for insecure connections
 export CLICKHOUSE_MCP_SERVER_TRANSPORT=stdio # or http or sse
+# Optional: mount the HTTP endpoint under a sub-path (default: /mcp).
+# Set when reverse-proxied behind a prefix so trailing-slash redirects
+# include it, e.g. /db/mcp when served at https://host/db/mcp.
+# export CLICKHOUSE_MCP_HTTP_PATH=/db/mcp
 ```
 
 ## Preparing the database

--- a/src/cbioportal_mcp/env.py
+++ b/src/cbioportal_mcp/env.py
@@ -60,6 +60,21 @@ class McpConfig:
         return int(os.getenv("CLICKHOUSE_MCP_BIND_PORT", "8000"))
 
     @property
+    def mcp_http_path(self) -> Optional[str]:
+        """Get the HTTP path under which to mount the MCP server.
+
+        Set when the server is reverse-proxied behind a sub-path so that
+        FastMCP's generated URLs (e.g. trailing-slash redirects) include
+        the external prefix. Example: "/db/mcp" when served at
+        https://host/db/mcp via Traefik without stripPrefix.
+
+        Only used when transport is "http" or "sse". When unset, FastMCP
+        uses its default path ("/mcp").
+        """
+        value = os.getenv("CLICKHOUSE_MCP_HTTP_PATH")
+        return value if value else None
+
+    @property
     def mcp_user(self) -> str:
         """Get the clickhouse user for which the MCP server is running for.
 

--- a/src/cbioportal_mcp/server.py
+++ b/src/cbioportal_mcp/server.py
@@ -214,7 +214,14 @@ def main():
         if transport in http_transports:
             # Use the configured bind host (defaults to 127.0.0.1, can be set to 0.0.0.0)
             # and bind port (defaults to 8000)
-            mcp.run(transport=transport, host=config.mcp_bind_host, port=config.mcp_bind_port)
+            run_kwargs = {
+                "transport": transport,
+                "host": config.mcp_bind_host,
+                "port": config.mcp_bind_port,
+            }
+            if config.mcp_http_path:
+                run_kwargs["path"] = config.mcp_http_path
+            mcp.run(**run_kwargs)
         else:
             # For stdio transport, no host or port is needed
             mcp.run(transport=transport)


### PR DESCRIPTION
## Summary

- Adds a `CLICKHOUSE_MCP_HTTP_PATH` env var that gets passed through to FastMCP's `mcp.run(path=...)`.
- Lets the HTTP endpoint be mounted at an external sub-path (e.g. `/db/mcp`) so trailing-slash redirects use the right URL when the server is reverse-proxied behind a prefix.
- Default unchanged when unset (FastMCP keeps using `/mcp`).

## Why

We just exposed the database MCP publicly at `https://mcp.cbioportal.org/db/mcp` via a Traefik `stripPrefix` middleware (knowledgesystems-k8s-deployment#470). That gets routing right, but FastMCP doesn't know about the `/db` prefix, so a request to `/db/mcp` (no trailing slash) gets a broken 307 redirect to `http://mcp.cbioportal.org/mcp/` — wrong path and wrong scheme.

Setting `CLICKHOUSE_MCP_HTTP_PATH=/db/mcp` and dropping the strip-prefix middleware lets FastMCP own the full external path, so redirects come back correct.

## Test plan

- [x] `mcp_http_path` returns `None` when env unset, the configured value when set.
- [ ] After deploy: `curl -i https://mcp.cbioportal.org/db/mcp` returns `307` redirecting to `https://mcp.cbioportal.org/db/mcp/` (not `http://.../mcp/`).
- [ ] `curl -i https://mcp.cbioportal.org/db/mcp/` still returns `405` (existing behavior).
- [ ] Default deployments without the env var continue to mount at `/mcp` unchanged.