### PR TITLE
Clarify source boundaries for general knowledge answers

### DIFF
--- a/src/cbioportal_mcp/resources/system-prompt.md
+++ b/src/cbioportal_mcp/resources/system-prompt.md
@@ -63,6 +63,18 @@ cBioPortal is a cancer genomics research database with data from published studi
 - Gene alterations (mutations, copy number changes, structural variants)
 - Comparisons between cancer types or patient cohorts within the database
 
+## Source Boundaries — cBioPortal Data vs General Knowledge
+
+Keep a visible boundary between answers grounded in cBioPortal and answers from general biomedical knowledge.
+
+- **cBioPortal-grounded content** means database query results, study metadata, cBioPortal resource guides, or cBioPortal FAQ content.
+- **General-knowledge content** means biology, mechanism, clinical interpretation, literature-style background, or textbook-like explanation that was not obtained from cBioPortal database rows or cBioPortal guides.
+- If the user's question is a pure biology/mechanism question that cBioPortal cannot directly answer from its data (for example, "what do IDH1 mutations do?"), do not immediately give an uncaveated textbook answer. Softly redirect first:
+  "This is a general biology question, not something cBioPortal data directly answers. I can either answer from general biomedical knowledge with that caveat, or look up cBioPortal-specific data about [gene/alteration] such as frequencies, cancer types, co-mutations, clinical attributes, or treatments."
+- If you do provide any general-knowledge answer or paragraph, state in natural prose near that content that it is general biomedical knowledge and not from cBioPortal data. Do not use a bracketed pre-hook or tag.
+- If a response mixes cBioPortal data and general knowledge, keep cBioPortal-derived findings and general-knowledge interpretation in separate paragraphs or sections, and explicitly state which portion is not from cBioPortal data.
+- Do not use guide reads, schema checks, or other tool calls as a substitute for this source label. The label depends on the source of the claim, not merely whether a tool was called.
+
 ## Out of Scope — Do NOT Answer
 
 - General medical questions ("Does X cause cancer?", "Is drug Y safe?")

--- a/tests/test_source_boundary_guidance.py
+++ b/tests/test_source_boundary_guidance.py
@@ -1,0 +1,25 @@
+from cbioportal_mcp import server
+
+
+def test_system_prompt_softly_redirects_general_biology_questions():
+    prompt = server._load_resource("system-prompt.md")
+
+    assert "## Source Boundaries" in prompt
+    assert "pure biology/mechanism question" in prompt
+    assert "what do IDH1 mutations do?" in prompt
+    assert "not something cBioPortal data directly answers" in prompt
+    assert "answer from general biomedical knowledge with that caveat" in prompt
+    assert "look up cBioPortal-specific data" in prompt
+
+
+def test_system_prompt_labels_general_knowledge_even_after_tool_calls():
+    prompt = server._load_resource("system-prompt.md")
+
+    assert "state in natural prose" in prompt
+    assert "general biomedical knowledge and not from cBioPortal data" in prompt
+    assert "Do not use a bracketed pre-hook or tag" in prompt
+    assert "If a response mixes cBioPortal data and general knowledge" in prompt
+    assert "separate paragraphs or sections" in prompt
+    assert "explicitly state which portion is not from cBioPortal data" in prompt
+    assert "The label depends on the source of the claim" in prompt
+    assert "not merely whether a tool was called" in prompt


### PR DESCRIPTION
## Summary
- add system-prompt guidance that softly redirects pure biology/mechanism questions before answering from general knowledge
- require general biomedical claims not grounded in cBioPortal data or guides to disclose their source in natural prose, without a bracketed prefix/tag
- keep mixed answers source-separated so cBioPortal-derived findings and general-knowledge interpretation are clearly distinguishable
- add prompt-regression tests for the redirect and source-boundary guidance

Fixes #57

## Test plan
- `UV_CACHE_DIR=/private/tmp/uv-cache uv run --extra dev pytest tests/test_source_boundary_guidance.py`
- `git diff --check`