### PR TITLE
Add targeted guides for agent issue patterns

### DIFF
--- a/src/cbioportal_mcp/resources/clinical-data-guide.md
+++ b/src/cbioportal_mcp/resources/clinical-data-guide.md
@@ -60,6 +60,56 @@ ORDER BY patient_attribute, attr_id;
 - **patient_attribute**: true = patient attribute, false = sample attribute
 - **cancer_study_id**: links to cancer_study table (filter by study)
 
+## Attribute Semantics and Matching
+
+### Case-Insensitive Matching for Attribute Values
+
+Clinical values are free text across studies and may differ only by case. For example, a controlled-looking value such as germline mutation status may appear as `GERMLINE`, `Germline`, or another case variant.
+
+When filtering `clinical_data_derived.attribute_value`, use case-insensitive matching unless you have already profiled the exact values in the target study:
+
+```sql
+-- Correct: case-insensitive clinical value filter
+SELECT DISTINCT sample_unique_id, patient_unique_id
+FROM clinical_data_derived
+WHERE cancer_study_identifier = 'your_study_id'
+  AND attribute_name = 'MUTATION_STATUS'
+  AND upper(attribute_value) = 'GERMLINE';
+```
+
+Do not write `attribute_value = 'GERMLINE'` without first checking all distinct values for that attribute in the study.
+
+### Query the Requested Attribute, Not a Proxy
+
+Do not infer one clinical attribute from a related subtype or marker. Query the actual requested attribute when it exists.
+
+Examples:
+
+- HER2-negative breast cancer: search for `HER2_STATUS`, `HER2`, IHC, or FISH attributes. Do not infer HER2 status from Luminal A/B subtype.
+- ER/PR status: query ER/PR clinical attributes directly. Do not infer from molecular subtype alone.
+- PD-L1 status: query PD-L1 attributes directly. Do not infer from cancer type or immune subtype.
+
+Discovery pattern:
+
+```sql
+SELECT DISTINCT
+    attribute_name,
+    attribute_value
+FROM clinical_data_derived
+WHERE cancer_study_identifier = 'brca_tcga_pan_can_atlas_2018'
+  AND (
+      upper(attribute_name) LIKE '%HER2%'
+      OR upper(attribute_name) LIKE '%ER_STATUS%'
+      OR upper(attribute_name) LIKE '%PR_STATUS%'
+      OR upper(attribute_name) LIKE '%IHC%'
+      OR upper(attribute_name) LIKE '%FISH%'
+  )
+ORDER BY attribute_name, attribute_value
+LIMIT 200;
+```
+
+If the requested attribute is absent, say it is absent and offer the closest available attribute as a proxy only with an explicit caveat.
+
 ## Finding Studies by Cancer Type
 
 When searching for studies about a specific cancer type (e.g., "glioblastoma studies"), **always start with `search_oncotree()`** to resolve the correct OncoTree codes.

--- a/src/cbioportal_mcp/resources/common-pitfalls.md
+++ b/src/cbioportal_mcp/resources/common-pitfalls.md
@@ -528,7 +528,71 @@ For an unusual-looking variant the user may have typed deliberately:
 
 **Synonymous-variant filter.** Most cBioPortal studies drop `Silent` calls during the MAF/import pipeline because they're not biologically interesting and not annotated. A literal query for a synonymous variant (e.g. BRAF V600V) will return 0 rows from almost every study — the correct answer is *"filtered out of the dataset"*, not *"does not exist"*.
 
-**Promoter mutations.** TERT promoter variants (C228T, C250T) are *not* missense — they sit in the 5' UTR/promoter. Don't search for them with a missense filter; use `mutation_variant LIKE '%promoter%'` or `Start_Position` ranges. See `mutation-frequency-guide.md` for the canonical pattern.
+**Promoter mutations.** TERT promoter variants (C228T, C250T) are *not* missense — they sit upstream of the coding sequence. Don't search for them with a missense filter, and don't count all `TERT` mutations as promoter mutations. First inspect the study's promoter profiles and available columns. See `mutation-frequency-guide.md` for the canonical pattern.
+
+### 17. 🚨 FLAWED PREMISE OR NONEXISTENT DATA FIELD
+
+If the user's question relies on a premise that conflicts with cBioPortal data or schema, surface that problem before running adjacent analyses.
+
+#### ❌ Wrong: plow forward with adjacent data
+
+> User: *"List expression values for tumors with the heavily discussed MAP2K1 codon 105 driver alteration that changes mRNA stability."*
+> Agent: runs broad MAP2K1 mutation and expression queries, then stitches together a story.
+
+#### ✅ Correct: validate the premise first
+
+> I need to validate the premise first. cBioPortal stores mutations, copy number, expression, methylation, clinical data, and some annotations, but I do not see an mRNA-stability field. I also should not assume a MAP2K1 codon-105 driver alteration exists without confirming it in the mutation data. I can check whether MAP2K1 codon 105 appears in this deployment, then separately retrieve expression values if it does.
+
+Use this pattern when:
+
+- the requested data field is not stored in cBioPortal
+- a named alteration/gene/study is not found
+- the user asserts biology that is not represented in the database
+- the query would require literature knowledge rather than cBioPortal data
+
+Do not query unrelated genes or "helpful" substitutes unless you state why and the user accepts the substitution.
+
+### 18. 🚨 OUT-OF-SCOPE DRIFT AFTER USER PUSHBACK
+
+If you decline a request because it is outside cBioPortal scope, hold that boundary when the user rephrases or pushes gently.
+
+Out of scope:
+
+- interpreting or critiquing external papers
+- creating presentation slides or methods-slide outlines
+- debugging Databricks, PySpark, Bokeh, lifelines, or external application code
+- giving treatment recommendations or drug-safety advice
+
+Correct response shape:
+
+> I can't analyze or critique the paper itself from cBioPortal data. If the paper's cohort is represented in cBioPortal, I can help query that study's mutations, clinical attributes, or treatment records.
+
+For external code failures:
+
+> That error is in an external Databricks/PySpark workflow, not in cBioPortal MCP. I can't debug that pipeline here, but I can help retrieve the cBioPortal data inputs you would need for your analysis.
+
+### 19. 🚨 MISLEADING OUTPUT PROMISES
+
+Do not promise outputs the MCP server cannot produce.
+
+- Kaplan-Meier plot: provide survival rows or summary data and hand off to cBioPortal Survival / R / Python.
+- CSV export: provide a compact table or query; do not claim to create a downloadable file.
+- Large patient-level dumps: summarize and offer a bounded query with `LIMIT`, or point to cBioPortal/DataHub download workflows.
+
+### 20. 🚨 MALFORMED TABLES AND UNCLEAR QUERY ERRORS
+
+When a query returns tabular data, keep columns aligned with values. Prefer JSON or a compact Markdown table generated directly from query column names.
+
+When a complex query fails:
+
+1. Identify the failing part if visible from the error message.
+2. Say which table, join, field, or filter could not be executed.
+3. Offer a smaller stepwise query.
+4. If possible, return partial results and name what is missing.
+
+Example:
+
+> The mutation filter can be run, but the expression-profile join failed because I could not identify a MYC expression profile for this study. I can first list available expression profiles, then intersect mutation-positive samples with expression values.
 
 ## Best Practices Summary
 
@@ -550,6 +614,9 @@ For an unusual-looking variant the user may have typed deliberately:
 16. **Always verify schema** — never assume tables or columns exist without checking first
 17. **Never fabricate OncoKB/driver annotations** — check for driver columns first
 18. **Never silently rewrite the user's query** — if "point mutation" or "V600V" is ambiguous or unusual, surface the normalization or ask, don't substitute. See pitfall #16.
+19. **Validate flawed premises early** — if the gene, alteration, study, or data field is absent, say so before running adjacent analyses.
+20. **Hold scope boundaries after refusal** — do not provide paper critiques, slide outlines, external pipeline code, or medical advice after user pushback.
+21. **Do not promise unavailable outputs** — provide data/handoffs instead of claiming to create plots, CSV files, or external apps.
 
 ## Validation Checklist
 
@@ -568,3 +635,6 @@ Before trusting your results, ask:
 - [ ] Before saying "out of scope", did I check `resource_sample`, `resource_patient`, `resource_study`, and `resource_definition` for external links?
 - [ ] Did I verify all tables and columns exist before querying them?
 - [ ] Did I answer the literal question, or did I silently rewrite it? If I normalized a term ("point mutation" → SNV set, "V600V" → V600E), did I surface that to the user?
+- [ ] Did I validate the user's premise before querying adjacent data?
+- [ ] Did I keep scope boundaries after any refusal?
+- [ ] Did I avoid promising plots, downloads, or external-code debugging that this MCP server cannot perform?

--- a/src/cbioportal_mcp/resources/external-resources-guide.md
+++ b/src/cbioportal_mcp/resources/external-resources-guide.md
@@ -1,0 +1,90 @@
+# External Resources Guide
+
+Use this guide when the user asks about data that may be linked from cBioPortal rather than stored directly in molecular or clinical tables.
+
+## Routing Triggers
+
+Read this guide before answering or refusing questions that mention:
+
+- imaging, radiology, CT, MRI, pathology slides, histology, Minerva, viewer
+- external portal, external resource, image data, spatial data
+- HTAN studies or study-specific linked viewers
+
+## Core Rule
+
+Do not say cBioPortal has no imaging or external-resource data until you have checked:
+
+- `resource_definition`
+- `resource_study`
+- `resource_sample`
+- `resource_patient`
+
+cBioPortal may store links to external viewers or portals even when it does not store raw images.
+
+## Discovery Query
+
+Start with table and column validation, then use this pattern:
+
+```sql
+SELECT
+    rd.resource_id,
+    rd.display_name,
+    rd.description,
+    rd.resource_type,
+    rs.cancer_study_identifier,
+    rs.url
+FROM resource_study rs
+JOIN resource_definition rd
+    ON rs.resource_id = rd.resource_id
+WHERE lower(rd.display_name) LIKE '%minerva%'
+   OR lower(rd.description) LIKE '%minerva%'
+   OR lower(rd.display_name) LIKE '%image%'
+   OR lower(rd.description) LIKE '%image%'
+   OR lower(rd.display_name) LIKE '%pathology%'
+   OR lower(rd.description) LIKE '%pathology%'
+   OR lower(rd.display_name) LIKE '%histology%'
+   OR lower(rd.description) LIKE '%histology%'
+ORDER BY rs.cancer_study_identifier, rd.display_name
+LIMIT 100;
+```
+
+If no study-level rows appear, check sample- and patient-level resource links:
+
+```sql
+SELECT
+    rd.resource_id,
+    rd.display_name,
+    rd.description,
+    rs.cancer_study_identifier,
+    rs.sample_unique_id,
+    rs.url
+FROM resource_sample rs
+JOIN resource_definition rd
+    ON rs.resource_id = rd.resource_id
+WHERE lower(rd.display_name) LIKE '%minerva%'
+   OR lower(rd.description) LIKE '%minerva%'
+   OR lower(rd.display_name) LIKE '%image%'
+   OR lower(rd.description) LIKE '%image%'
+   OR lower(rd.display_name) LIKE '%pathology%'
+   OR lower(rd.description) LIKE '%pathology%'
+   OR lower(rd.display_name) LIKE '%histology%'
+   OR lower(rd.description) LIKE '%histology%'
+ORDER BY rs.cancer_study_identifier, rd.display_name
+LIMIT 100;
+```
+
+## Answer Pattern
+
+If links exist:
+
+> cBioPortal does not store the raw image files in the molecular/clinical tables, but this deployment has external resource links for some studies. I found links to [resource names] in [studies]. These point to external viewers or portals rather than image pixels stored directly in cBioPortal.
+
+If links do not exist:
+
+> I checked the cBioPortal external-resource tables (`resource_definition`, `resource_study`, `resource_sample`, and `resource_patient`) and did not find matching imaging or viewer links in this deployment.
+
+## Do Not
+
+- Do not answer "no imaging data" from general knowledge alone.
+- Do not infer that lack of image columns means no linked image resources.
+- Do not return huge resource tables; summarize studies/resources and include a small sample of URLs.

--- a/src/cbioportal_mcp/resources/faq-guide.md
+++ b/src/cbioportal_mcp/resources/faq-guide.md
@@ -35,6 +35,65 @@ Also cite the specific study publication(s) whose data you used.
 
 Note: Synonymous mutations are not included in cBioPortal.
 
+## Data Types Usually Not Stored Directly
+
+cBioPortal generally does not store:
+
+- raw CT, MRI, pathology-slide, or histology image files
+- raw sequencing files such as BAM, CRAM, or FASTQ
+- polygenic risk scores as a standard data type
+- full external clinical-trial databases
+
+However, this deployment may contain links to external viewers or portals through `resource_*` tables. For imaging, pathology, Minerva, HTAN, or viewer questions, read `cbioportal://external-resources-guide` and check those tables before saying the data is absent.
+
+## What the MCP Agent Can and Cannot Produce
+
+The MCP agent can:
+
+- query cBioPortal data and return tables in text/JSON/Markdown
+- summarize counts, frequencies, and available attributes
+- provide cBioPortal study links and DataHub download links when applicable
+- provide SQL snippets or handoff instructions for R/Python/cBioPortal tools
+
+The MCP agent should not promise to:
+
+- render Kaplan-Meier plots or other visual figures directly
+- export large CSV files or create downloadable files
+- run external notebooks, Databricks jobs, PySpark pipelines, or web apps
+
+If the user asks for plots or downloads, provide the underlying data in a compact table when feasible and redirect them to cBioPortal's built-in visualization/download features or an appropriate external workflow.
+
+## Clinical Actionability and OncoKB
+
+cBioPortal data alone is not enough to answer clinical actionability questions such as "Are TP53 mutations clinically actionable?"
+
+Answer actionability questions only if actionability/driver annotation data is available and has been queried. Otherwise:
+
+- state that cBioPortal alone does not establish clinical actionability
+- suggest checking OncoKB or the cBioPortal web interface for curated annotations
+- do not provide therapeutic recommendations from general model knowledge
+
+## Germline Variant Studies
+
+cBioPortal can represent germline variant studies when germline variants and associated clinical data are loaded as a study. Many visualization and correlation features used for somatic variants can also be useful for germline studies, provided the data is modeled correctly.
+
+For germline-study setup questions, explain:
+
+- a study can be built around germline variants plus clinical attributes
+- clinical data can be used for stratification and plots just as in other studies
+- mutation status values may vary by study and should be matched case-insensitively in queries
+- the user should follow cBioPortal datahub/import formats for study submission
+
+## Adding Data to cBioPortal
+
+When asked how to add clinical or genomic data to cBioPortal, first ask whether the user wants to:
+
+- submit data to the public cBioPortal
+- run or populate a private cBioPortal instance
+- visualize their own data without full submission
+
+For public cBioPortal, point users to the cBioPortal data curation process and datahub formats. For private instances, explain that they need a valid study package with clinical, sample, molecular, and metadata files. For quick visualization without submission, mention cBioPortal standalone tools such as Mutation Mapper and OncoPrint when applicable.
+
 ## Reference Genome
 
 The public cBioPortal largely uses **hg19/GRCh37**. However, some studies use **hg38/GRCh38**, including datasets sourced from the GDC (Genomic Data Commons).

--- a/src/cbioportal_mcp/resources/gene-resolution-guide.md
+++ b/src/cbioportal_mcp/resources/gene-resolution-guide.md
@@ -1,0 +1,55 @@
+# Gene Resolution Guide
+
+Use this guide before querying gene expression, mutation, copy-number, methylation, or structural-variant data when the user's gene term may be ambiguous.
+
+## Routing Triggers
+
+Read this guide when the user mentions:
+
+- a gene family shorthand: `CD3`, `HLA`, `KRT`, `MUC`, `MT-`, `IGH`, `IGK`, `IGL`
+- a marker name that may refer to multiple genes or proteins
+- a gene alias, old symbol, or informal name
+- a wildcard-like term such as "all CD3 genes"
+
+These examples are not exhaustive. Apply this guide to any gene term that may resolve to multiple symbols, aliases, paralogs, family members, or marker genes.
+
+## Core Rule
+
+Do not silently aggregate multiple genes when the user names an ambiguous symbol. Either ask for clarification or choose a clearly standard marker and state the choice.
+
+For example, "CD3 expression" can refer to `CD3D`, `CD3E`, or `CD3G`; in many immune-marker contexts `CD3E` is the standard marker, but the agent must not average all CD3 genes unless the user asks for a combined signature.
+
+## Gene Discovery Query
+
+After validating the gene table exists, search exact symbols first, then prefix/alias-like matches:
+
+```sql
+SELECT
+    hugo_gene_symbol,
+    entrez_gene_id
+FROM gene
+WHERE upper(hugo_gene_symbol) = upper('CD3')
+   OR upper(hugo_gene_symbol) LIKE upper('CD3%')
+ORDER BY hugo_gene_symbol
+LIMIT 50;
+```
+
+If aliases are available in this deployment, inspect the relevant alias table before assuming no match. If no alias table exists, state that alias resolution is limited to available gene symbols.
+
+## Answer Pattern
+
+If multiple plausible genes are found:
+
+> "CD3" is ambiguous in cBioPortal gene-symbol terms. I found `CD3D`, `CD3E`, and `CD3G`. Did you mean `CD3E` as a T-cell marker, or should I analyze all three separately?
+
+If the user clearly asks for a combined family/signature:
+
+- report each gene separately by default
+- only compute an average/signature if the user explicitly requests it
+- state exactly how the combined value was calculated
+
+## Do Not
+
+- Do not average multiple genes into one expression value without explicit permission.
+- Do not rewrite an ambiguous symbol to a single gene without telling the user.
+- Do not treat a prefix match as a validated gene symbol.

--- a/src/cbioportal_mcp/resources/mutation-frequency-guide.md
+++ b/src/cbioportal_mcp/resources/mutation-frequency-guide.md
@@ -19,6 +19,62 @@ If your query returns a frequency over 100%, **do not try to debug or explain th
 
 Rewrite the query using one of the canonical patterns below (either single-study or the [Cross-Cancer-Type](#cross-cancer-type-mutation-frequency) recipe). Do **not** loop on diagnostic queries trying to attribute the >100% to "data inconsistencies" — there are none.
 
+## Promoter and Non-Coding Mutation Questions
+
+When the user mentions "promoter", "non-coding", `C228T`, `C250T`, `-124C>T`, `-146C>T`, or "TERT promoter", do not treat the question as "all mutations in the gene."
+
+TERT promoter mutations are a common special case:
+
+- `C228T` corresponds to `-124C>T` in the TERT promoter.
+- `C250T` corresponds to `-146C>T` in the TERT promoter.
+- These are upstream promoter alterations, not protein-coding amino-acid substitutions.
+- They may live in promoter-specific mutation profiles or be flagged differently from coding variants depending on the study.
+
+### Required Workflow
+
+1. Inspect available molecular profiles / columns for the study before querying.
+2. Look for promoter-specific profiles or fields before falling back to `genomic_event_derived`.
+3. If using `genomic_event_derived`, filter to promoter/non-coding records explicitly. Do not report all `TERT` mutation records as promoter mutations.
+4. If the needed promoter fields/profiles are absent in the deployment, say so and do not substitute coding mutations.
+
+Schema exploration pattern:
+
+```sql
+SELECT DISTINCT
+    cancer_study_identifier,
+    genetic_profile_id,
+    genetic_alteration_type,
+    datatype,
+    name
+FROM genetic_profile
+WHERE cancer_study_identifier = 'your_study_id'
+  AND (
+      lower(genetic_profile_id) LIKE '%promoter%'
+      OR lower(name) LIKE '%promoter%'
+  )
+ORDER BY genetic_profile_id;
+```
+
+If promoter data is present, inspect exact mutation fields before counting:
+
+```sql
+SELECT *
+FROM genomic_event_derived
+WHERE cancer_study_identifier = 'your_study_id'
+  AND hugo_gene_symbol = 'TERT'
+LIMIT 20;
+```
+
+Then use only columns that actually encode promoter/non-coding status, genomic position, or the canonical promoter alleles. If no such columns exist, answer that this deployment does not expose enough promoter-specific fields for the requested count.
+
+### Answer Pattern
+
+> I treated this as a promoter-mutation question, not an all-TERT-mutation question. I only counted records from promoter-specific data/fields. Coding TERT mutations are excluded.
+
+If promoter data cannot be identified:
+
+> I found TERT mutation records, but I do not see promoter-specific fields or profiles needed to distinguish C228T/C250T promoter mutations in this deployment. I should not report all TERT mutations as promoter mutations.
+
 ## Cross-Cancer-Type Mutation Frequency
 
 When the user asks about a gene "across cancer types" or "in different cancers", look up the right cohort in **`cancer_study_query_preferences`** and group by the per-sample `CANCER_TYPE` clinical attribute. Never hand-pick study lists yourself.

--- a/src/cbioportal_mcp/resources/study-resolution-guide.md
+++ b/src/cbioportal_mcp/resources/study-resolution-guide.md
@@ -1,0 +1,50 @@
+# Study Resolution Guide
+
+Use this guide when the user names a study, cohort, portal, or data source that may not exist in the connected cBioPortal deployment.
+
+## Routing Triggers
+
+Read this guide when the user mentions:
+
+- PBTA, Pediatric Brain Tumor Atlas, pediatric cBioPortal, Kids First
+- GENIE, AACR GENIE, MSK private cohorts, institutional cohorts
+- "download study", "which study", "find cohort", "data from [portal]"
+- a named cohort that `list_studies(search=...)` does not find
+
+## Core Rules
+
+1. Resolve the requested study before substituting another study.
+2. If the requested study is not in this deployment, say so explicitly.
+3. Do not silently analyze a substitute cohort.
+4. If the user agrees to a substitute, keep a one-line scope caveat when reporting numbers.
+
+## Known External cBioPortal Instances
+
+These are not necessarily queryable from this MCP server, but they are useful redirects:
+
+| User wording | Likely external instance | Scope |
+|---|---|---|
+| PBTA, Pediatric Brain Tumor Atlas, pediatric brain tumors | https://pedcbioportal.kidsfirstdrc.org/ | Pediatric cancer studies, including pediatric brain tumor cohorts |
+| GENIE | https://genie.cbioportal.org/ | AACR GENIE data access, depending on release and permissions |
+| MSK private / institutional cohorts | private institutional cBioPortal deployments | Not queryable from public cBioPortal unless exported to the public database |
+
+## Study Resolution Workflow
+
+1. Call `list_studies(search=...)` with the user's exact study/cohort phrase and close variants.
+2. If a cancer type is mentioned, call `search_oncotree(search_term)` before disease-level study discovery.
+3. If no matching study is found, check known external instances above before declaring the study absent.
+4. If proposing a substitute, describe why it is a substitute and how its scope differs.
+
+## Substitute-Cohort Answer Pattern
+
+> I cannot query PBTA from this cBioPortal deployment. PBTA is typically accessed through pediatric cBioPortal at https://pedcbioportal.kidsfirstdrc.org/. I can analyze `[substitute_study_id]` here, but its results should not be interpreted as PBTA results.
+
+When reporting numbers from a substitute:
+
+> Scope note: these counts are from `[substitute_study_id]` in this deployment, not from the requested PBTA cohort.
+
+## Do Not
+
+- Do not answer a PBTA question with `brain_cptac_2020` numbers without a scope warning.
+- Do not let later turns drop the substitute-cohort warning.
+- Do not claim a study does not exist globally; say it is not available in the connected deployment.

--- a/src/cbioportal_mcp/resources/system-prompt.md
+++ b/src/cbioportal_mcp/resources/system-prompt.md
@@ -13,8 +13,11 @@ BEFORE ANSWERING ANY QUESTION, you MUST:
    - **Group comparison, p-value, mutual exclusivity, co-occurrence, hazard ratio, median survival, "aggressive"/"better outcome" questions**: read `cbioportal://statistical-tests-guide`. Pay attention to the **HARD RULES** at the top — ClickHouse cannot run tests, and you must never invent a p-value, fabricate a "median" from `AVG()`, or report median OS without Kaplan-Meier. Use the Approved Response Templates to hand off to cBioPortal Group Comparison / R / Python.
    - Clinical data questions: read `cbioportal://clinical-data-guide`
    - Sample/study filtering: read `cbioportal://sample-filtering-guide`
+   - Missing, external, or substitute study/cohort questions (PBTA, pediatric cBioPortal, GENIE, private portals): read `cbioportal://study-resolution-guide`
    - Treatment questions: read `cbioportal://treatment-guide`
    - **Gene expression / copy-number / methylation / correlation between two genes**: read `cbioportal://gene-expression-guide`. This is the home for `genetic_alteration_derived` and the `gene_pair_coexpression` view. Don't try to answer expression-correlation questions through mutation-frequency tools.
+   - Ambiguous gene symbols, marker names, aliases, or gene-family shorthands (e.g. CD3): read `cbioportal://gene-resolution-guide`
+   - Imaging, pathology, histology, radiology, Minerva, HTAN, or external-viewer questions: read `cbioportal://external-resources-guide`
    - General cBioPortal questions (history, features, data types, how to cite): read `cbioportal://faq-guide`
    - Cancer type disambiguation: call `search_oncotree(search_term)`
    - When unsure: read `cbioportal://common-pitfalls`

--- a/src/cbioportal_mcp/server.py
+++ b/src/cbioportal_mcp/server.py
@@ -288,6 +288,15 @@ def _statistical_tests_guide_text() -> str:
 def _gene_expression_guide_text() -> str:
     return _load_resource("gene-expression-guide.md")
 
+def _external_resources_guide_text() -> str:
+    return _load_resource("external-resources-guide.md")
+
+def _gene_resolution_guide_text() -> str:
+    return _load_resource("gene-resolution-guide.md")
+
+def _study_resolution_guide_text() -> str:
+    return _load_resource("study-resolution-guide.md")
+
 # --- MCP resources (decorator registers them) --------------------------------
 @mcp.resource("cbioportal://mutation-frequency-guide")
 def mutation_frequency_guide() -> str:
@@ -321,6 +330,18 @@ def statistical_tests_guide() -> str:
 def gene_expression_guide() -> str:
     return _gene_expression_guide_text()
 
+@mcp.resource("cbioportal://external-resources-guide")
+def external_resources_guide() -> str:
+    return _external_resources_guide_text()
+
+@mcp.resource("cbioportal://gene-resolution-guide")
+def gene_resolution_guide() -> str:
+    return _gene_resolution_guide_text()
+
+@mcp.resource("cbioportal://study-resolution-guide")
+def study_resolution_guide() -> str:
+    return _study_resolution_guide_text()
+
 
 @mcp.tool(
     description="""
@@ -330,6 +351,9 @@ def gene_expression_guide() -> str:
     - cbioportal://mutation-frequency-guide - Gene mutation frequency calculations with proper denominators
     - cbioportal://clinical-data-guide - Patient vs sample-level clinical data queries
     - cbioportal://sample-filtering-guide - Study and sample type filtering strategies
+    - cbioportal://external-resources-guide - External linked resources such as imaging viewers
+    - cbioportal://gene-resolution-guide - Ambiguous gene symbols and aliases
+    - cbioportal://study-resolution-guide - Missing studies, external portals, and substitute cohorts
     - cbioportal://common-pitfalls - Common query mistakes and how to avoid them
 
     Returns:
@@ -505,6 +529,18 @@ def list_guides() -> list[dict]:
             "description": "Gene expression / copy-number / methylation analysis. Covers genetic_alteration_derived, profile_type discovery, and the gene_pair_coexpression view for Spearman correlation between two genes"
         },
         {
+            "uri": "cbioportal://external-resources-guide",
+            "description": "Guide for finding external linked resources such as imaging, pathology, Minerva, HTAN, or other resource_* table links before declaring data unavailable"
+        },
+        {
+            "uri": "cbioportal://gene-resolution-guide",
+            "description": "Guide for resolving ambiguous gene symbols, aliases, gene families, and shorthand such as CD3 before querying expression or alteration data"
+        },
+        {
+            "uri": "cbioportal://study-resolution-guide",
+            "description": "Guide for resolving requested studies, avoiding silent substitute cohorts, and redirecting to known external cBioPortal instances when data is not in this deployment"
+        },
+        {
             "uri": "cbioportal://study-guide/{study_id}",
             "description": "Dynamic study-specific guide - use get_study_guide(study_id) tool to generate"
         }
@@ -529,7 +565,10 @@ def read_guide(uri: str) -> str:
         "cbioportal://treatment-guide": _treatment_guide_text(),
         "cbioportal://faq-guide": _faq_guide_text(),
         "cbioportal://statistical-tests-guide": _statistical_tests_guide_text(),
-        "cbioportal://gene-expression-guide": _gene_expression_guide_text()
+        "cbioportal://gene-expression-guide": _gene_expression_guide_text(),
+        "cbioportal://external-resources-guide": _external_resources_guide_text(),
+        "cbioportal://gene-resolution-guide": _gene_resolution_guide_text(),
+        "cbioportal://study-resolution-guide": _study_resolution_guide_text()
     }
 
     if uri not in resources:

--- a/tests/test_guide_layer_issue_coverage.py
+++ b/tests/test_guide_layer_issue_coverage.py
@@ -1,0 +1,62 @@
+import inspect
+
+from cbioportal_mcp import server
+
+
+def test_new_targeted_guides_are_registered_and_readable():
+    server_source = inspect.getsource(server)
+
+    assert "cbioportal://external-resources-guide" in server_source
+    assert "cbioportal://gene-resolution-guide" in server_source
+    assert "cbioportal://study-resolution-guide" in server_source
+
+    assert "resource_definition" in server._external_resources_guide_text()
+    assert "CD3D" in server._gene_resolution_guide_text()
+    assert "These examples are not exhaustive" in server._gene_resolution_guide_text()
+    assert "pedcbioportal.kidsfirstdrc.org" in server._study_resolution_guide_text()
+
+
+def test_new_targeted_guides_stay_concise():
+    targeted_guides = [
+        server._external_resources_guide_text(),
+        server._gene_resolution_guide_text(),
+        server._study_resolution_guide_text(),
+    ]
+
+    for guide in targeted_guides:
+        assert len(guide.split()) < 500
+
+
+def test_system_prompt_routes_to_targeted_guides():
+    prompt = server._load_resource("system-prompt.md")
+
+    assert "cbioportal://study-resolution-guide" in prompt
+    assert "cbioportal://gene-resolution-guide" in prompt
+    assert "cbioportal://external-resources-guide" in prompt
+    assert "PBTA" in prompt
+    assert "CD3" in prompt
+    assert "Minerva" in prompt
+
+
+def test_existing_guides_cover_open_issue_patterns():
+    clinical = server._clinical_data_guide_text()
+    mutation = server._mutation_frequency_guide_text()
+    faq = server._faq_guide_text()
+    pitfalls = server._common_pitfalls_guide_text()
+
+    assert "Case-Insensitive Matching for Attribute Values" in clinical
+    assert "Query the Requested Attribute, Not a Proxy" in clinical
+    assert "HER2" in clinical
+
+    assert "Promoter and Non-Coding Mutation Questions" in mutation
+    assert "C228T" in mutation
+    assert "all mutations in the gene" in mutation
+    assert "Do not report all `TERT` mutation records as promoter mutations" in mutation
+
+    assert "Clinical Actionability and OncoKB" in faq
+    assert "polygenic risk scores" in faq
+    assert "should not promise" in faq
+
+    assert "FLAWED PREMISE OR NONEXISTENT DATA FIELD" in pitfalls
+    assert "OUT-OF-SCOPE DRIFT AFTER USER PUSHBACK" in pitfalls
+    assert "MISLEADING OUTPUT PROMISES" in pitfalls


### PR DESCRIPTION
## Summary
- add three narrowly routed guides for recurring agent failure modes: external resources, gene-symbol resolution, and study/cohort resolution
- expand existing domain guides with focused sections for clinical attribute semantics, promoter/non-coding variants, capability boundaries, actionability, germline/data-submission questions, flawed-premise handling, and out-of-scope drift
- register the new guides with MCP resources/listing/read access and add minimal system-prompt routing lines so the prompt stays a router rather than the full instruction store
- add regression coverage that verifies the guides are exposed, key issue patterns are covered, and the new targeted guides stay concise

## Why this approach
We do not want to fix every agent issue by adding more always-on system-prompt text. That makes the prompt less focused and pushes many conditional details into every answer. This PR keeps the system prompt small and uses it mostly for routing: when a question mentions PBTA, CD3, Minerva/imaging, etc., the agent is pointed to a targeted guide that contains the concrete workflow.

This keeps stable, conditional domain knowledge in MCP resources where it can be loaded only when relevant. Mechanical or schema-level problems should still be fixed with SQL/views/tools where possible; these guide changes are for cases where the agent needs interpretation rules, examples, or scoped answer patterns.

## Issue categorization
- Data/query mechanics that need canonical workflows: mutation-frequency mismatch and promoter/non-coding handling (#53, #65, related #70) are addressed in the mutation guide rather than the system prompt.
- Clinical attribute semantics: case-insensitive clinical values and avoiding proxy inference (#56, #52) are addressed in the clinical-data guide.
- Discovery/routing failures: imaging/resource links (#58), ambiguous gene symbols (#37), and missing/external cohorts (#42/#51-style substitute cohort risk) get dedicated small guides.
- Scope/source/capability boundaries: actionability (#24), unavailable data types (#21), germline/data-submission support (#20/#26), output promises (#28), flawed premises (#67), out-of-scope drift (#69), and unclear errors/tables (#35/#29) are handled in FAQ/common-pitfalls where worked response patterns are more appropriate than long prompt text.

## Guide bloat control
- The new guides are intentionally narrow and trigger-based: one guide per routing decision, not one guide per bug.
- Current sizes are small: external resources ~372 words, gene resolution ~330 words, study resolution ~382 words.
- `test_new_targeted_guides_stay_concise` enforces a `<500`-word budget for each new targeted guide, so future edits cannot quietly turn these into prompt-sized documents.
- The system prompt only gains three routing lines; detailed recipes live in resources.

## Test plan
- `UV_CACHE_DIR=/private/tmp/uv-cache uv run --extra dev pytest`
- `git diff --check`
- `UV_CACHE_DIR=/private/tmp/uv-cache uv run --extra dev ruff check tests/test_guide_layer_issue_coverage.py`

Note: a targeted `ruff check src/cbioportal_mcp/server.py ...` still reports pre-existing lint issues on `upstream/main` in `server.py` unrelated to this PR, so this PR only treats the new test-file lint as meaningful.
