### PR TITLE
Trust X-Forwarded-* in uvicorn so reverse-proxy redirects stay on https

### DIFF
--- a/src/cbioportal_mcp/env.py
+++ b/src/cbioportal_mcp/env.py
@@ -75,6 +75,29 @@ class McpConfig:
         return value if value else None
 
     @property
+    def mcp_forwarded_allow_ips(self) -> Optional[str]:
+        """Get the set of upstream IPs whose X-Forwarded-* headers uvicorn
+        should trust. Forwarded as `forwarded_allow_ips` to `uvicorn.Config`.
+
+        Set this when the server sits behind a reverse proxy that
+        terminates TLS (e.g. Traefik with an https Ingress) — otherwise
+        uvicorn ignores `X-Forwarded-Proto: https` and builds redirect
+        Locations from its own scheme (http), which strict clients refuse
+        to follow.
+
+        Common values:
+          - "*"                  trust any upstream (fine inside a Pod
+                                 reachable only via in-cluster Services)
+          - "10.0.0.0/8,..."     scope to a CIDR (e.g. the Traefik LB
+                                 source range)
+
+        Only used when transport is "http" or "sse". When unset, uvicorn
+        defaults apply (trust only 127.0.0.1, no proxy_headers).
+        """
+        value = os.getenv("CLICKHOUSE_MCP_FORWARDED_ALLOW_IPS")
+        return value if value else None
+
+    @property
     def mcp_user(self) -> str:
         """Get the clickhouse user for which the MCP server is running for.
 

--- a/src/cbioportal_mcp/server.py
+++ b/src/cbioportal_mcp/server.py
@@ -245,19 +245,19 @@ def main():
                 "transport": transport,
                 "host": config.mcp_bind_host,
                 "port": config.mcp_bind_port,
-                # Trust X-Forwarded-* headers from any source. Behind a
-                # reverse proxy (e.g. Traefik) that terminates TLS, uvicorn
-                # otherwise builds redirect Locations from its own scheme
-                # (http) and the trailing-slash 307 on /mcp downgrades
-                # https → http — Claude Desktop and similar strict clients
-                # refuse to follow.
-                "uvicorn_config": {
-                    "proxy_headers": True,
-                    "forwarded_allow_ips": "*",
-                },
             }
             if config.mcp_http_path:
                 run_kwargs["path"] = config.mcp_http_path
+            # Behind a TLS-terminating reverse proxy, uvicorn must trust
+            # X-Forwarded-Proto or the trailing-slash 307 on /mcp will
+            # downgrade https → http and strict clients (e.g. Claude
+            # Desktop) refuse to follow. Opt-in via env so direct
+            # deployments aren't asked to trust spoofed headers.
+            if config.mcp_forwarded_allow_ips:
+                run_kwargs["uvicorn_config"] = {
+                    "proxy_headers": True,
+                    "forwarded_allow_ips": config.mcp_forwarded_allow_ips,
+                }
             mcp.run(**run_kwargs)
         else:
             # For stdio transport, no host or port is needed

--- a/src/cbioportal_mcp/server.py
+++ b/src/cbioportal_mcp/server.py
@@ -245,6 +245,16 @@ def main():
                 "transport": transport,
                 "host": config.mcp_bind_host,
                 "port": config.mcp_bind_port,
+                # Trust X-Forwarded-* headers from any source. Behind a
+                # reverse proxy (e.g. Traefik) that terminates TLS, uvicorn
+                # otherwise builds redirect Locations from its own scheme
+                # (http) and the trailing-slash 307 on /mcp downgrades
+                # https → http — Claude Desktop and similar strict clients
+                # refuse to follow.
+                "uvicorn_config": {
+                    "proxy_headers": True,
+                    "forwarded_allow_ips": "*",
+                },
             }
             if config.mcp_http_path:
                 run_kwargs["path"] = config.mcp_http_path


### PR DESCRIPTION
## Why

Externally, the DB MCP at \`https://mcp.cbioportal.org/db/mcp\` is reached via Traefik (TLS-terminated). FastMCP mounts the MCP handler under the path, so a request without trailing slash gets a 307 redirect to add one. Without \`proxy_headers\`, uvicorn ignores Traefik's \`X-Forwarded-Proto: https\` and builds the redirect Location from its own scheme:

\`\`\`
$ curl -sI https://mcp.cbioportal.org/db/mcp
HTTP/2 307
location: http://mcp.cbioportal.org/db/mcp/   ← scheme downgrade
server: uvicorn
\`\`\`

Claude Desktop (and any client that refuses https → http downgrade) bails with "Couldn't connect". The /navigator/mcp route doesn't have this problem because it's an Express server that returns the canonical 406 directly without redirecting.

## Fix

Add a new env var \`CLICKHOUSE_MCP_FORWARDED_ALLOW_IPS\`. When set, the server passes \`uvicorn_config={"proxy_headers": True, "forwarded_allow_ips": <value>}\` to \`mcp.run()\`. FastMCP 2.10.6's \`run_http_async\` forwards the dict into \`uvicorn.Config(...)\`, so uvicorn then honors \`X-Forwarded-Proto\` / \`X-Forwarded-For\` / \`X-Forwarded-Host\` from upstream and the 307 Location becomes \`https://...\`.

When unset, behavior is unchanged (uvicorn defaults — trust only 127.0.0.1, no \`proxy_headers\`). Opt-in keeps non-proxied deployments from trusting spoofed headers.

Values:
- \`"*"\`                — trust any upstream (right for the k8s deployments here, where the listener is only reachable via in-cluster Services from Traefik or sibling Pods)
- \`"10.0.0.0/8,..."\`   — scope to a CIDR (e.g. the Traefik LB source range)
- unset                  — defaults; no proxy header trust

## Follow-up

A second PR in knowledgesystems-k8s-deployment will set \`CLICKHOUSE_MCP_FORWARDED_ALLOW_IPS=*\` on both the public and MSK MCP Deployments. Without that PR this code change is a no-op.

## Test plan

- [ ] Deploy this image to the 203 MCP Deployment with the env var set to \`*\`.
- [ ] \`curl -sI https://mcp.cbioportal.org/db/mcp\` returns \`Location: https://mcp.cbioportal.org/db/mcp/\` (not http).
- [ ] Claude Desktop connects to \`https://mcp.cbioportal.org/db/mcp\` and lists the DB MCP tools.
- [ ] LibreChat's existing in-cluster call to \`http://cbioagent-clickhouse-mcp/db/mcp\` still works (no X-Forwarded-Proto sent, so uvicorn just uses its actual scheme — http — for the redirect, same as before).
- [ ] With the env var unset, behavior matches main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)