### PR TITLE
Add gene and external resource resolution tools

### DIFF
--- a/src/cbioportal_mcp/resources/external-resources-guide.md
+++ b/src/cbioportal_mcp/resources/external-resources-guide.md
@@ -21,9 +21,13 @@ Do not say cBioPortal has no imaging or external-resource data until you have ch
 
 cBioPortal may store links to external viewers or portals even when it does not store raw images.
 
+## Preferred Tool
+
+Call `find_external_resources(search, study_search, limit)` first. Use `search` for the resource concept (for example, `Minerva imaging pathology`) and `study_search` for a study/cohort filter (for example, `HTAN`).
+
 ## Discovery Query
 
-Start with table and column validation, then use this pattern:
+If the tool is unavailable or you need to inspect the exact SQL shape, start with table and column validation, then use this pattern:
 
 ```sql
 SELECT

--- a/src/cbioportal_mcp/resources/gene-resolution-guide.md
+++ b/src/cbioportal_mcp/resources/gene-resolution-guide.md
@@ -19,9 +19,13 @@ Do not silently aggregate multiple genes when the user names an ambiguous symbol
 
 For example, "CD3 expression" can refer to `CD3D`, `CD3E`, or `CD3G`; in many immune-marker contexts `CD3E` is the standard marker, but the agent must not average all CD3 genes unless the user asks for a combined signature.
 
+## Preferred Tool
+
+Call `resolve_gene_symbol(term)` first. Use the returned exact, prefix, and contains matches to decide whether the term is a single HUGO symbol, an ambiguous family/marker, or an unmatched term.
+
 ## Gene Discovery Query
 
-After validating the gene table exists, search exact symbols first, then prefix/alias-like matches:
+If the tool is unavailable or you need to inspect the SQL shape, validate the gene table exists, then search exact symbols first, followed by prefix/alias-like matches:
 
 ```sql
 SELECT

--- a/src/cbioportal_mcp/resources/system-prompt.md
+++ b/src/cbioportal_mcp/resources/system-prompt.md
@@ -16,8 +16,8 @@ BEFORE ANSWERING ANY QUESTION, you MUST:
    - Missing, external, or substitute study/cohort questions (PBTA, pediatric cBioPortal, GENIE, private portals): read `cbioportal://study-resolution-guide`
    - Treatment questions: read `cbioportal://treatment-guide`
    - **Gene expression / copy-number / methylation / correlation between two genes**: read `cbioportal://gene-expression-guide`. This is the home for `genetic_alteration_derived` and the `gene_pair_coexpression` view. Don't try to answer expression-correlation questions through mutation-frequency tools.
-   - Ambiguous gene symbols, marker names, aliases, or gene-family shorthands (e.g. CD3): read `cbioportal://gene-resolution-guide`
-   - Imaging, pathology, histology, radiology, Minerva, HTAN, or external-viewer questions: read `cbioportal://external-resources-guide`
+   - Ambiguous gene symbols, marker names, aliases, or gene-family shorthands (e.g. CD3): call `resolve_gene_symbol(term)` and read `cbioportal://gene-resolution-guide`
+   - Imaging, pathology, histology, radiology, Minerva, HTAN, or external-viewer questions: call `find_external_resources(...)` and read `cbioportal://external-resources-guide`
    - General cBioPortal questions (history, features, data types, how to cite): read `cbioportal://faq-guide`
    - Cancer type disambiguation: call `search_oncotree(search_term)`
    - When unsure: read `cbioportal://common-pitfalls`

--- a/src/cbioportal_mcp/server.py
+++ b/src/cbioportal_mcp/server.py
@@ -96,6 +96,30 @@ def _sanitize_search_term(search: str) -> str:
     sanitized = sanitized.replace("_", "\\_")
     return sanitized
 
+def _sanitize_sql_literal(value: str) -> str:
+    """Escape a string for use inside a single-quoted SQL literal."""
+    return value.replace("'", "''")
+
+def _split_search_terms(search: str, defaults: list[str] | None = None) -> list[str]:
+    """Split a user search string into bounded SQL LIKE terms."""
+    if not search:
+        return defaults or []
+    terms = [term.strip() for term in re.split(r"[,;]", search) if term.strip()]
+    if len(terms) == 1:
+        terms = [term for term in re.split(r"\s+", search) if term.strip()]
+    return terms[:10]
+
+def _like_any_expression(columns: list[str], terms: list[str]) -> str:
+    """Build a case-insensitive LIKE-any expression for already-trusted column names."""
+    if not terms:
+        return "1 = 1"
+    predicates = []
+    for term in terms:
+        safe_term = _sanitize_sql_literal(term.lower())
+        for column in columns:
+            predicates.append(f"lower({column}) LIKE '%{safe_term}%'")
+    return "(" + " OR ".join(predicates) + ")"
+
 # Resource loading using importlib.resources for proper package support
 def _get_resources_path() -> Path:
     """Get the resources directory path, supporting both installed packages and dev mode."""
@@ -481,6 +505,227 @@ def zip_select_query_result(ch_query_result) -> list[dict]:
     for row in rows:
         result.append({k: v for k, v in zip(columns, row) if v not in ("", None)})
     return result
+
+
+def _resolve_gene_symbol_impl(term: str, limit: int = 25) -> dict:
+    """Resolve a user-provided gene term to exact, prefix, and contains matches."""
+    query_term = term.strip()
+    if not query_term:
+        return {"error": "term cannot be empty"}
+
+    safe_limit = max(1, min(int(limit), MAX_LIST_LIMIT))
+    safe_term = _sanitize_sql_literal(query_term.upper())
+    exact_query = f"""
+        SELECT DISTINCT
+            hugo_gene_symbol,
+            entrez_gene_id
+        FROM gene
+        WHERE upper(hugo_gene_symbol) = '{safe_term}'
+        ORDER BY hugo_gene_symbol
+        LIMIT {safe_limit}
+    """
+    prefix_query = f"""
+        SELECT DISTINCT
+            hugo_gene_symbol,
+            entrez_gene_id
+        FROM gene
+        WHERE upper(hugo_gene_symbol) LIKE '{safe_term}%'
+          AND upper(hugo_gene_symbol) != '{safe_term}'
+        ORDER BY hugo_gene_symbol
+        LIMIT {safe_limit}
+    """
+    contains_query = f"""
+        SELECT DISTINCT
+            hugo_gene_symbol,
+            entrez_gene_id
+        FROM gene
+        WHERE upper(hugo_gene_symbol) LIKE '%{safe_term}%'
+          AND upper(hugo_gene_symbol) NOT LIKE '{safe_term}%'
+        ORDER BY hugo_gene_symbol
+        LIMIT {safe_limit}
+    """
+
+    exact_matches = run_select_query(exact_query)
+    prefix_matches = run_select_query(prefix_query)
+    contains_matches = run_select_query(contains_query)
+
+    is_ambiguous = len(exact_matches) != 1 or bool(prefix_matches)
+    if exact_matches and not prefix_matches:
+        recommendation = (
+            f"Use {exact_matches[0].get('hugo_gene_symbol')} as the resolved HUGO symbol."
+        )
+    elif exact_matches and prefix_matches:
+        recommendation = (
+            "The term is an exact HUGO symbol but also prefixes other genes; ask whether the "
+            "user means the exact gene or a gene family/signature."
+        )
+    elif prefix_matches:
+        recommendation = (
+            "No exact HUGO symbol matched. Ask the user to choose from the prefix matches, "
+            "or analyze each listed gene separately if they asked for a family."
+        )
+    elif contains_matches:
+        recommendation = (
+            "No exact or prefix HUGO symbol matched. Treat contains matches as suggestions, "
+            "not as validated substitutions."
+        )
+    else:
+        recommendation = "No HUGO symbol matches were found in the gene table."
+
+    return {
+        "query_term": query_term,
+        "is_ambiguous": is_ambiguous,
+        "exact_matches": exact_matches,
+        "prefix_matches": prefix_matches,
+        "contains_matches": contains_matches,
+        "recommendation": recommendation,
+    }
+
+
+def _run_external_resource_query(scope: str, query: str) -> dict:
+    try:
+        return {"scope": scope, "rows": run_select_query(query)}
+    except Exception as e:
+        logger.info("find_external_resources %s query failed: %s", scope, e)
+        return {"scope": scope, "error_message": str(e), "rows": []}
+
+
+def _find_external_resources_impl(
+    search: str = "imaging Minerva pathology histology radiology",
+    study_search: str | None = None,
+    limit: int = 25,
+) -> dict:
+    """Find external resources linked from study/sample/patient resource tables."""
+    terms = _split_search_terms(
+        search,
+        defaults=["imaging", "minerva", "pathology", "histology", "radiology"],
+    )
+    safe_limit = max(1, min(int(limit), MAX_LIST_LIMIT))
+    resource_filter = _like_any_expression(
+        ["rd.display_name", "rd.description", "rd.resource_type"],
+        terms,
+    )
+    study_filter = ""
+    if study_search:
+        study_terms = _split_search_terms(study_search)
+        study_filter = " AND " + _like_any_expression(
+            ["cs.cancer_study_identifier", "cs.name", "cs.description"],
+            study_terms,
+        )
+
+    study_query = f"""
+        SELECT
+            'study' AS scope,
+            rd.resource_id,
+            rd.display_name,
+            rd.description,
+            rd.resource_type,
+            cs.cancer_study_identifier,
+            cs.name AS study_name,
+            rs.url
+        FROM resource_study rs
+        JOIN resource_definition rd ON rs.resource_id = rd.resource_id
+        JOIN cancer_study cs ON rs.internal_id = cs.cancer_study_id
+        WHERE {resource_filter}
+        {study_filter}
+        ORDER BY cs.cancer_study_identifier, rd.display_name
+        LIMIT {safe_limit}
+    """
+    sample_query = f"""
+        SELECT
+            'sample' AS scope,
+            rd.resource_id,
+            rd.display_name,
+            rd.description,
+            rd.resource_type,
+            cs.cancer_study_identifier,
+            cs.name AS study_name,
+            s.stable_id AS sample_id,
+            rs.url
+        FROM resource_sample rs
+        JOIN resource_definition rd ON rs.resource_id = rd.resource_id
+        JOIN sample s ON rs.internal_id = s.internal_id
+        JOIN patient p ON s.patient_id = p.internal_id
+        JOIN cancer_study cs ON p.cancer_study_id = cs.cancer_study_id
+        WHERE {resource_filter}
+        {study_filter}
+        ORDER BY cs.cancer_study_identifier, rd.display_name, s.stable_id
+        LIMIT {safe_limit}
+    """
+    patient_query = f"""
+        SELECT
+            'patient' AS scope,
+            rd.resource_id,
+            rd.display_name,
+            rd.description,
+            rd.resource_type,
+            cs.cancer_study_identifier,
+            cs.name AS study_name,
+            p.stable_id AS patient_id,
+            rp.url
+        FROM resource_patient rp
+        JOIN resource_definition rd ON rp.resource_id = rd.resource_id
+        JOIN patient p ON rp.internal_id = p.internal_id
+        JOIN cancer_study cs ON p.cancer_study_id = cs.cancer_study_id
+        WHERE {resource_filter}
+        {study_filter}
+        ORDER BY cs.cancer_study_identifier, rd.display_name, p.stable_id
+        LIMIT {safe_limit}
+    """
+
+    sections = [
+        _run_external_resource_query("study", study_query),
+        _run_external_resource_query("sample", sample_query),
+        _run_external_resource_query("patient", patient_query),
+    ]
+    total_rows = sum(len(section.get("rows", [])) for section in sections)
+    return {
+        "search_terms": terms,
+        "study_search": study_search,
+        "total_rows": total_rows,
+        "sections": sections,
+        "note": (
+            "Rows are external links stored by cBioPortal; they do not mean raw image "
+            "or external files are stored directly in cBioPortal tables."
+        ),
+    }
+
+
+@mcp.tool()
+def resolve_gene_symbol(term: str, limit: int = 25) -> dict:
+    """Resolve a gene symbol, alias-like term, marker, or family shorthand.
+
+    Use before querying expression/alteration data when a user-provided term may
+    match multiple HUGO symbols, such as CD3, HLA, KRT, MUC, IGH, or any marker
+    name that may represent a gene family.
+    """
+    try:
+        return _resolve_gene_symbol_impl(term=term, limit=limit)
+    except Exception as e:
+        logger.error("resolve_gene_symbol error: %s", e)
+        return {"error": str(e)}
+
+
+@mcp.tool()
+def find_external_resources(
+    search: str = "imaging Minerva pathology histology radiology",
+    study_search: str = None,
+    limit: int = 25,
+) -> dict:
+    """Find external links stored in cBioPortal resource tables.
+
+    Use before saying cBioPortal has no imaging, pathology, histology, HTAN,
+    Minerva, viewer, or other externally linked resources.
+    """
+    try:
+        return _find_external_resources_impl(
+            search=search,
+            study_search=study_search,
+            limit=limit,
+        )
+    except Exception as e:
+        logger.error("find_external_resources error: %s", e)
+        return {"error": str(e)}
 
 
 # Resource Access Tools for AI Agents

--- a/tests/test_resolution_helper_tools.py
+++ b/tests/test_resolution_helper_tools.py
@@ -1,0 +1,59 @@
+from cbioportal_mcp import server
+
+
+def test_resolve_gene_symbol_separates_exact_and_family_matches(monkeypatch):
+    queries = []
+
+    def fake_run_select_query(query):
+        queries.append(query)
+        if "upper(hugo_gene_symbol) = 'CD3'" in query:
+            return []
+        if "upper(hugo_gene_symbol) LIKE 'CD3%'" in query:
+            return [
+                {"hugo_gene_symbol": "CD3D", "entrez_gene_id": 915},
+                {"hugo_gene_symbol": "CD3E", "entrez_gene_id": 916},
+                {"hugo_gene_symbol": "CD3G", "entrez_gene_id": 917},
+            ]
+        return []
+
+    monkeypatch.setattr(server, "run_select_query", fake_run_select_query)
+
+    result = server._resolve_gene_symbol_impl("CD3")
+
+    assert result["query_term"] == "CD3"
+    assert result["is_ambiguous"] is True
+    assert result["exact_matches"] == []
+    assert [row["hugo_gene_symbol"] for row in result["prefix_matches"]] == [
+        "CD3D",
+        "CD3E",
+        "CD3G",
+    ]
+    assert "Ask the user to choose from the prefix matches" in result["recommendation"]
+    assert len(queries) == 3
+
+
+def test_find_external_resources_queries_all_resource_scopes(monkeypatch):
+    queries = []
+
+    def fake_run_select_query(query):
+        queries.append(query)
+        if "FROM resource_study" in query:
+            return [{"scope": "study", "display_name": "Minerva", "url": "https://example.org"}]
+        return []
+
+    monkeypatch.setattr(server, "run_select_query", fake_run_select_query)
+
+    result = server._find_external_resources_impl(
+        search="Minerva imaging",
+        study_search="HTAN",
+    )
+
+    assert result["search_terms"] == ["Minerva", "imaging"]
+    assert result["study_search"] == "HTAN"
+    assert result["total_rows"] == 1
+    assert [section["scope"] for section in result["sections"]] == ["study", "sample", "patient"]
+    assert any("FROM resource_study" in query for query in queries)
+    assert any("FROM resource_sample" in query for query in queries)
+    assert any("FROM resource_patient" in query for query in queries)
+    assert all("cancer_study" in query for query in queries)
+    assert all("htan" in query.lower() for query in queries)


### PR DESCRIPTION
## Summary
- add `resolve_gene_symbol(term, limit)` to resolve exact, prefix, and contains matches from the `gene` table before expression/alteration queries
- add `find_external_resources(search, study_search, limit)` to search study-, sample-, and patient-level `resource_*` links before declaring imaging/pathology/external resources absent
- update the system prompt and the relevant guides so agents call the concrete tools first, with guide SQL as fallback/reference
- add focused unit tests for both helper-tool implementations

## Why these tools
The guide-layer PR moved recurring failure modes out of the always-on system prompt and into conditional resources. These two cases benefit from going one level deeper than guides:

- **Ambiguous gene symbols (#37):** guidance can tell the agent not to average `CD3D`/`CD3E`/`CD3G`, but a tool gives it a concrete resolution step and structured output (`exact_matches`, `prefix_matches`, `contains_matches`, `is_ambiguous`, `recommendation`).
- **External resource links (#58):** guidance can tell the agent to check `resource_*` tables before saying "no imaging data", but a tool makes the check consistent across `resource_study`, `resource_sample`, and `resource_patient` and keeps the response bounded with a limit.

This keeps the system prompt as a router while making the high-risk discovery steps mechanical and testable.

## Tool behavior
### `resolve_gene_symbol(term, limit)`
- searches exact HUGO symbol matches
- separately searches prefix/family-style matches
- separately searches contains matches as suggestions only
- flags ambiguous terms when there is not exactly one clean exact match or when prefix matches exist
- returns a recommendation telling the agent whether to use the exact symbol or ask for clarification

### `find_external_resources(search, study_search, limit)`
- searches matching resource definitions by display name, description, and resource type
- searches across study-, sample-, and patient-level resource links
- supports optional study/cohort filtering, e.g. `HTAN`
- returns separate sections by scope plus a note that these are external links, not raw files stored directly in cBioPortal

## Test plan
- `UV_CACHE_DIR=/private/tmp/uv-cache uv run --extra dev pytest`
- `git diff --check`
- `UV_CACHE_DIR=/private/tmp/uv-cache uv run --extra dev ruff check tests/test_resolution_helper_tools.py tests/test_guide_layer_issue_coverage.py`

Full local pytest result: 10 passed.
