### PR TITLE
Stop reporting a study-lookup miss as "the study does not exist" (#80)

### DIFF
--- a/src/cbioportal_mcp/server.py
+++ b/src/cbioportal_mcp/server.py
@@ -125,39 +125,30 @@ def _load_study_guide(study_id: str) -> str | None:
     """Load a study guide from the study-guides directory if it exists.
 
     Study identifiers are lowercase by convention, but users and agents type them in
-    any case. Falling back to a case-insensitive match stops 'BRCA_TCGA_Pan_Can_Atlas_2018'
-    from silently missing a guide that is present on disk.
+    any case. Resolving to the canonical on-disk name first lets us cleanly separate
+    "no such guide" (None) from "guide exists but couldn't be read" (raises), rather
+    than collapsing both into a silent None.
     """
-    try:
-        resources_path = _get_resources_path()
-        study_file = resources_path / "study-guides" / f"{study_id}.md"
-        return study_file.read_text(encoding="utf-8")
-    except FileNotFoundError:
-        pass
-    except Exception as e:
-        logger.error(f"Error loading study guide for {study_id}: {e}")
-        return None
-
     canonical = _resolve_study_guide_name(study_id)
     if canonical is None:
         return None
-    try:
-        resources_path = _get_resources_path()
-        return (resources_path / "study-guides" / f"{canonical}.md").read_text(encoding="utf-8")
-    except Exception as e:
-        logger.error(f"Error loading study guide for {canonical}: {e}")
-        return None
+    resources_path = _get_resources_path()
+    return (resources_path / "study-guides" / f"{canonical}.md").read_text(encoding="utf-8")
 
 def _resolve_study_guide_name(study_id: str) -> str | None:
     """Return the on-disk guide name matching study_id ignoring case, if any."""
     wanted = study_id.lower()
     for name in _list_available_study_guides():
-        if name.lower() == wanted and name != study_id:
+        if name.lower() == wanted:
             return name
     return None
 
+@lru_cache(maxsize=1)
 def _list_available_study_guides() -> list[str]:
-    """List all available pre-generated study guides."""
+    """List all available pre-generated study guides.
+
+    Cached — guides are baked into the image and don't change at runtime.
+    """
     try:
         resources_path = _get_resources_path()
         study_guides_path = resources_path / "study-guides"
@@ -187,8 +178,12 @@ def _load_general_guide(name: str) -> str | None:
         logger.error(f"Error loading general guide {name}: {e}")
         return None
 
+@lru_cache(maxsize=1)
 def _list_available_general_guides() -> list[str]:
-    """List general guide names available in resources/guides/."""
+    """List general guide names available in resources/guides/.
+
+    Cached — guides are baked into the image and don't change at runtime.
+    """
     try:
         resources_path = _get_resources_path()
         guides_path = resources_path / "guides"
@@ -725,12 +720,19 @@ def get_study_guide(study_id: str) -> str:
     except ValueError as e:
         return f"Error: {str(e)}"
     
-    # First, check for a pre-generated guide file
-    static_guide = _load_study_guide(study_id)
+    # First, check for a pre-generated guide file. `_load_study_guide` returns
+    # None when no guide file exists (fall through to dynamic); it raises when
+    # a guide was resolved but couldn't be read — that's a real problem and
+    # we surface it rather than silently degrading.
+    try:
+        static_guide = _load_study_guide(study_id)
+    except Exception as e:
+        logger.error(f"Error reading resolved static guide for {study_id}: {e}")
+        return f"Error: A study guide was found for '{study_id}' but could not be read: {e}"
     if static_guide:
         logger.info(f"Loaded static study guide for {study_id}")
         return static_guide
-    
+
     # Fall back to dynamic generation
     logger.info(f"Generating dynamic study guide for {study_id}")
     try:

--- a/src/cbioportal_mcp/server.py
+++ b/src/cbioportal_mcp/server.py
@@ -122,16 +122,39 @@ def _load_resource(filename: str) -> str:
         return f"Error: Could not load resource: {filename}"
 
 def _load_study_guide(study_id: str) -> str | None:
-    """Load a study guide from the study-guides directory if it exists."""
+    """Load a study guide from the study-guides directory if it exists.
+
+    Study identifiers are lowercase by convention, but users and agents type them in
+    any case. Falling back to a case-insensitive match stops 'BRCA_TCGA_Pan_Can_Atlas_2018'
+    from silently missing a guide that is present on disk.
+    """
     try:
         resources_path = _get_resources_path()
         study_file = resources_path / "study-guides" / f"{study_id}.md"
         return study_file.read_text(encoding="utf-8")
     except FileNotFoundError:
-        return None
+        pass
     except Exception as e:
         logger.error(f"Error loading study guide for {study_id}: {e}")
         return None
+
+    canonical = _resolve_study_guide_name(study_id)
+    if canonical is None:
+        return None
+    try:
+        resources_path = _get_resources_path()
+        return (resources_path / "study-guides" / f"{canonical}.md").read_text(encoding="utf-8")
+    except Exception as e:
+        logger.error(f"Error loading study guide for {canonical}: {e}")
+        return None
+
+def _resolve_study_guide_name(study_id: str) -> str | None:
+    """Return the on-disk guide name matching study_id ignoring case, if any."""
+    wanted = study_id.lower()
+    for name in _list_available_study_guides():
+        if name.lower() == wanted and name != study_id:
+            return name
+    return None
 
 def _list_available_study_guides() -> list[str]:
     """List all available pre-generated study guides."""
@@ -620,6 +643,67 @@ def get_general_guide(name: str) -> str:
     return content
 
 
+def _similar_study_identifiers(study_id: str, limit: int = 10) -> list[dict]:
+    """Find studies whose identifier shares a token with study_id.
+
+    Used only to help the agent recover from a near-miss identifier. Tokens come from
+    an already-validated study_id, so they are safe to interpolate.
+    """
+    tokens = [t for t in re.split(r"[_-]+", study_id.lower()) if len(t) >= 3]
+    if not tokens:
+        return []
+    clauses = " OR ".join(f"lower(cancer_study_identifier) LIKE '%{t}%'" for t in tokens)
+    try:
+        return run_select_query(f"""
+            SELECT cancer_study_identifier, name
+            FROM cancer_study
+            WHERE {clauses}
+            LIMIT {int(limit)}
+        """) or []
+    except Exception as e:
+        logger.error(f"Error looking up studies similar to {study_id}: {e}")
+        return []
+
+
+def _study_not_in_deployment_message(study_id: str) -> str:
+    """Explain a study-lookup miss without asserting the study does not exist.
+
+    The previous wording ("Study 'X' not found") was relayed to users as "this study
+    does not exist in cBioPortal", which was wrong for studies that are live on
+    cbioportal.org, restricted by permissions, or simply spelled differently.
+    """
+    lines = [
+        f"Identifier '{study_id}' did not match any study in the database this "
+        f"deployment is connected to.",
+        "",
+        "This is NOT proof the study does not exist. Before you tell the user it is "
+        "unavailable, rule out all three of these:",
+        "",
+        f"1. **Different identifier.** Search rather than guess: "
+        f"`SELECT cancer_study_identifier, name FROM cancer_study "
+        f"WHERE lower(name) LIKE '%<disease>%'`.",
+        "2. **Another cBioPortal instance.** Public cbioportal.org, pedcbioportal, and "
+        "GENIE hold different study sets — read `cbioportal://study-resolution-guide`.",
+        "3. **Access restriction.** A study the current credentials cannot read is "
+        "absent from these results, which is a permissions outcome, not a missing study.",
+    ]
+
+    candidates = _similar_study_identifiers(study_id)
+    if candidates:
+        lines += ["", "Studies in this deployment with a similar identifier:", ""]
+        for row in candidates:
+            ident = row.get("cancer_study_identifier", "?")
+            name = row.get("name", "")
+            lines.append(f"- `{ident}`" + (f" — {name}" if name else ""))
+
+    lines += [
+        "",
+        f"Do not tell the user that '{study_id}' does not exist. Say it is not in this "
+        f"deployment, and offer the candidates above or the other instances.",
+    ]
+    return "\n".join(lines)
+
+
 @mcp.tool()
 def get_study_guide(study_id: str) -> str:
     """Get a guide for a specific cBioPortal study.
@@ -653,20 +737,25 @@ def get_study_guide(study_id: str) -> str:
         guide_sections = []
         
         # 1. Basic study info
+        # Match case-insensitively: identifiers are lowercase by convention, but a
+        # user who types 'NBL_MSK_2023' must not be told the study is missing.
         study_info = run_select_query(f"""
-            SELECT 
+            SELECT
                 cancer_study_identifier,
                 name,
                 description,
                 type_of_cancer_id
-            FROM cancer_study 
-            WHERE cancer_study_identifier = '{study_id}'
+            FROM cancer_study
+            WHERE lower(cancer_study_identifier) = lower('{study_id}')
         """)
-        
+
         if not study_info:
-            return f"Study '{study_id}' not found. Use clickhouse_list_tables or query cancer_study table to find valid study identifiers."
-        
+            return _study_not_in_deployment_message(study_id)
+
         info = study_info[0]
+        # Adopt the identifier exactly as the database spells it, so every section
+        # below queries the real study rather than the user's casing.
+        study_id = info.get("cancer_study_identifier") or study_id
         guide_sections.append(f"""# Study Guide: {info.get('name', study_id)}
 
 **Study ID:** `{study_id}`

--- a/tests/test_study_lookup.py
+++ b/tests/test_study_lookup.py
@@ -1,0 +1,114 @@
+"""Study-identifier resolution (issue #80).
+
+The bot told users a study "does not exist" when it was live on cbioportal.org. Two
+defects fed that: the lookup was case-sensitive, and the miss message asserted
+non-existence instead of describing a deployment-scoped lookup failure.
+"""
+
+import pytest
+
+from cbioportal_mcp import server
+
+
+def _guide(study_id: str) -> str:
+    """Call the tool's underlying function; @mcp.tool wraps it in a FunctionTool."""
+    return server.get_study_guide.fn(study_id)
+
+
+CANCER_STUDY_ROW = {
+    "cancer_study_identifier": "nbl_msk_2023",
+    "name": "Neuroblastoma (MSK, 2023)",
+    "description": "A study that exists.",
+    "type_of_cancer_id": "nbl",
+}
+
+
+@pytest.fixture
+def fake_db(monkeypatch):
+    """Stand in for ClickHouse: only the exact lowercase identifier is stored."""
+    seen = []
+
+    def run_select_query(query: str):
+        seen.append(" ".join(query.split()))
+        q = query.lower()
+        if "from cancer_study" in q and "lower(cancer_study_identifier) = lower(" in q:
+            # The column is case-sensitive in ClickHouse; only a case-insensitive
+            # comparison can match the stored lowercase identifier.
+            return [CANCER_STUDY_ROW] if "nbl_msk_2023" in q else []
+        if "from cancer_study" in q and "like" in q:
+            return [
+                {"cancer_study_identifier": "nbl_target_2018", "name": "Neuroblastoma (TARGET)"}
+            ]
+        return []
+
+    monkeypatch.setattr(server, "run_select_query", run_select_query)
+    return seen
+
+
+def test_lookup_is_case_insensitive(fake_db):
+    """'NBL_MSK_2023' must resolve to the stored lowercase study."""
+    out = _guide("NBL_MSK_2023")
+    assert "does not exist" not in out
+    assert "did not match any study" not in out
+    assert "Neuroblastoma (MSK, 2023)" in out
+
+
+def test_downstream_sections_use_the_canonical_identifier(fake_db):
+    """After resolving, later queries must use the DB's spelling, not the user's."""
+    _guide("NBL_MSK_2023")
+    followups = [q for q in fake_db if "clinical_data_derived" in q]
+    assert followups, "expected the cohort-statistics query to run"
+    for q in followups:
+        assert "'nbl_msk_2023'" in q, f"query kept the user's casing: {q}"
+
+
+def test_miss_message_never_asserts_nonexistence(monkeypatch):
+    monkeypatch.setattr(server, "run_select_query", lambda q: [])
+    out = _guide("totally_made_up_study")
+
+    assert "does not exist" in out  # only as the instruction NOT to say it
+    assert "Do not tell the user that 'totally_made_up_study' does not exist." in out
+    assert "did not match any study in the database" in out
+
+
+def test_miss_message_lists_the_three_recoverable_causes(monkeypatch):
+    monkeypatch.setattr(server, "run_select_query", lambda q: [])
+    out = _guide("nbl_msk_9999")
+
+    assert "Different identifier" in out
+    assert "Another cBioPortal instance" in out
+    assert "Access restriction" in out
+    assert "cbioportal://study-resolution-guide" in out
+
+
+def test_miss_message_offers_similar_identifiers(fake_db):
+    out = _guide("nbl_msk_9999")
+    assert "similar identifier" in out
+    assert "nbl_target_2018" in out
+
+
+def test_similar_study_lookup_tolerates_a_db_error(monkeypatch):
+    def boom(query: str):
+        raise RuntimeError("clickhouse unavailable")
+
+    monkeypatch.setattr(server, "run_select_query", boom)
+    # A failing candidate lookup must not turn the miss message into an exception.
+    assert server._similar_study_identifiers("nbl_msk_2023") == []
+
+
+def test_similar_study_lookup_ignores_short_tokens(monkeypatch):
+    monkeypatch.setattr(server, "run_select_query", lambda q: pytest.fail("should not query"))
+    assert server._similar_study_identifiers("a_b") == []
+
+
+def test_static_guide_resolves_case_insensitively():
+    """A real guide on disk must be found regardless of the requested casing."""
+    available = server._list_available_study_guides()
+    assert available, "expected bundled study guides"
+    name = available[0]
+    assert server._load_study_guide(name) is not None
+    assert server._load_study_guide(name.upper()) is not None
+
+
+def test_unknown_static_guide_still_returns_none():
+    assert server._load_study_guide("no_such_study_guide_xyz") is None


### PR DESCRIPTION
Addresses #80.

Users were told `nbl_msk_2023` does not exist in cBioPortal while it was live on cbioportal.org, and the bot kept refusing even after the user pasted the study URL. Two defects in `get_study_guide` fed that, and both are in this repo (consistent with @fuzhaoyuan's comment that the failures happen on the database MCP tools).

## 1. The lookup was case-sensitive

```python
WHERE cancer_study_identifier = '{study_id}'
```

`cancer_study_identifier` is case-sensitive in ClickHouse, so a user or agent typing `NBL_MSK_2023` gets zero rows and the study looks missing. Same bug class as #56, one table over.

The comparison is now case-insensitive, and — importantly — the identifier is re-read from the result so the sections below query the study as the database spells it. Without that, a case variant would have resolved the study but then produced empty cohort statistics and profile lists. The on-disk `study-guides/*.md` lookup resolves case-insensitively too.

## 2. The miss message asserted non-existence

```python
return f"Study '{study_id}' not found. Use clickhouse_list_tables or query cancer_study table to find valid study identifiers."
```

An LLM relays "not found" to the user as "this study does not exist" — which is what #80 reports. Zero rows from one deployment's database is not evidence about the study's existence.

The message now states only what was observed, then gives the agent somewhere to go:

```
Identifier 'nbl_msk_2023' did not match any study in the database this deployment is
connected to.

This is NOT proof the study does not exist. Before you tell the user it is
unavailable, rule out all three of these:

1. **Different identifier.** Search rather than guess: `SELECT cancer_study_identifier,
   name FROM cancer_study WHERE lower(name) LIKE '%<disease>%'`.
2. **Another cBioPortal instance.** Public cbioportal.org, pedcbioportal, and GENIE
   hold different study sets — read `cbioportal://study-resolution-guide`.
3. **Access restriction.** A study the current credentials cannot read is absent from
   these results, which is a permissions outcome, not a missing study.

Studies in this deployment with a similar identifier:

- `nbl_target_2018` — Neuroblastoma (TARGET, 2018)
- `nbl_amc_2012` — Neuroblastoma (AMC, 2012)

Do not tell the user that 'nbl_msk_2023' does not exist. Say it is not in this
deployment, and offer the candidates above or the other instances.
```

This covers the third bullet of the issue's suggested fix (404 vs 403 ambiguity) at the level this repo can observe it: the tool cannot see an HTTP status, but it can refuse to convert "no rows" into "does not exist".

## Why the tool level, not the prompt

Per `AGENTS.md`, the fix hierarchy prefers eliminating the error source over documenting it. `cbioportal://study-resolution-guide` already covers missing studies, and the agent still got this wrong — a guide cannot talk an agent out of a query that genuinely returned no rows. Changing what the tool returns removes the false premise instead of arguing with it.

## Tests

`tests/test_study_lookup.py`, 10 cases, `run_select_query` stubbed so no ClickHouse is needed:

- `NBL_MSK_2023` resolves to the stored lowercase study
- follow-up queries use the canonical casing, not the request's
- the miss message never asserts non-existence and names all three causes
- similar identifiers are offered, and a failing candidate lookup degrades to no suggestions rather than an exception
- short tokens (`a_b`) do not trigger a wildcard scan
- static guides resolve case-insensitively; genuinely unknown ones still return `None`

```
22 passed
```

`ruff` on `server.py` goes from 83 to 81 pre-existing findings (a couple of trailing-whitespace lines were in the block I rewrote); the new test file is clean.

## Unrelated note

On a fresh `uv pip install -e ".[dev]"` the whole suite fails to import: `mcp-clickhouse==0.1.11` passes `dependencies=` to `FastMCP`, which current fastmcp rejects. `uv sync` (fastmcp 2.10.6 from `uv.lock`) works. Worth pinning in `pyproject.toml` so contributors do not hit it — happy to file that separately.