### PR TITLE
Add a study-view frequency reconciliation procedure (#53)

### DIFF
--- a/src/cbioportal_mcp/resources/mutation-frequency-guide.md
+++ b/src/cbioportal_mcp/resources/mutation-frequency-guide.md
@@ -42,6 +42,68 @@ If your query returns a frequency over 100%, **do not try to debug or explain th
 
 Rewrite the query using one of the canonical patterns below (either single-study or the [Cross-Cancer-Type](#cross-cancer-type-mutation-frequency) recipe). Do **not** loop on diagnostic queries trying to attribute the >100% to "data inconsistencies" — there are none.
 
+## When the user says your numbers don't match the study view
+
+The STOP rule above only fires above 100%. The more common failure is a frequency that
+looks perfectly reasonable and is still wrong, because the study view computes
+
+    frequency = numberOfAlteredCases / numberOfProfiledCases
+
+and both terms are easy to get subtly wrong. Ground truth for any study is the same
+endpoint the study view itself uses:
+
+```
+POST https://www.cbioportal.org/api/mutated-genes/fetch
+Content-Type: application/json
+
+{"studyIds": ["glioma_mskcc_2019"]}
+```
+
+Field semantics, because two of these are traps:
+
+| Field | Meaning | Use as |
+|---|---|---|
+| `numberOfAlteredCases` | distinct **samples** with >=1 mutation in the gene | numerator |
+| `numberOfProfiledCases` | distinct samples profiled **for that gene** | denominator |
+| `totalCount` | mutation **events**, not samples | never a numerator |
+| `numberOfAlteredCasesOnPanel` | altered cases restricted to panel-covered samples | panel-only views |
+
+### The denominator is per-gene, and the numerator is per-sample
+
+Both mistakes are silent. In `glioma_mskcc_2019` (1,004 samples):
+
+| gene | altered samples | profiled for gene | events | study view | `totalCount` / 1004 |
+|---|--:|--:|--:|--:|--:|
+| TERT | 604 | **882** | 623 | **68.5%** | 62.1% |
+| TP53 | 405 | 1004 | 511 | **40.3%** | 50.9% |
+| EGFR | 146 | 1004 | 197 | **14.5%** | 19.6% |
+| ATRX | 222 | 1004 | 255 | **22.1%** | 25.4% |
+
+TERT is profiled in 882 of 1,004 samples, so a study-wide denominator understates it.
+TP53 has 511 mutation events across 405 samples, so counting events overstates it. In
+that one study the profiled denominator takes 10 distinct values across 485 genes
+(45 to 1,004), and **268 of 485 genes have more events than altered samples** — so
+`COUNT(*)` is wrong for the majority of genes, not for an unlucky few.
+
+Note the errors run in both directions. A number being lower than the UI does not mean
+you were conservative; it means the denominator was wrong too.
+
+### Reconciliation procedure
+
+When a user reports a mismatch, do not defend the number and do not attribute it to
+"data inconsistencies" — there are none. Work through this in order:
+
+1. Numerator is `COUNT(DISTINCT sample_unique_id)`, never `COUNT(*)` and never `SUM`.
+2. Denominator comes from `sample_to_gene_panel_derived` **for that gene**, unioned with
+   `mutation_wes_coverage` so WES samples are not dropped (see the STOP rule).
+3. `mutation_status != 'UNCALLED'` and `off_panel = 0` are both applied.
+4. Numerator and denominator cover the **same sample set** — same study list, same
+   filters. A cohort filter applied to only one of them produces exactly this symptom.
+5. State the counting unit you used (samples vs patients). The study view counts samples.
+
+If the mismatch survives all five, say so plainly and report both your number and the
+UI's rather than picking one.
+
 ## Promoter and Non-Coding Mutation Questions
 
 When the user mentions "promoter", "non-coding", `C228T`, `C250T`, `-124C>T`, `-146C>T`, or "TERT promoter", do not treat the question as "all mutations in the gene."

--- a/tests/test_guide_layer_issue_coverage.py
+++ b/tests/test_guide_layer_issue_coverage.py
@@ -60,3 +60,38 @@ def test_existing_guides_cover_open_issue_patterns():
     assert "FLAWED PREMISE OR NONEXISTENT DATA FIELD" in pitfalls
     assert "OUT-OF-SCOPE DRIFT AFTER USER PUSHBACK" in pitfalls
     assert "MISLEADING OUTPUT PROMISES" in pitfalls
+
+
+def test_frequency_guide_covers_study_view_reconciliation():
+    """Issue #53: agent frequencies diverge from the cBioPortal UI.
+
+    The pre-existing STOP rule only fires above 100%; #53 is the silently-plausible
+    case. These assertions pin the reconciliation guidance and the two field-level
+    traps that cause it.
+    """
+    guide = server._mutation_frequency_guide_text()
+
+    assert "When the user says your numbers don't match the study view" in guide
+    assert "numberOfAlteredCases / numberOfProfiledCases" in guide
+    assert "/api/mutated-genes/fetch" in guide
+
+    # totalCount is mutation events, not samples - the most common numerator bug.
+    assert "mutation **events**, not samples" in guide
+    assert "never a numerator" in guide
+
+    # The denominator is per-gene, evidenced with real numbers.
+    assert "The denominator is per-gene, and the numerator is per-sample" in guide
+    assert "268 of 485 genes have more events than altered samples" in guide
+
+    # A five-step procedure, not just a warning.
+    assert "Reconciliation procedure" in guide
+    for required in ("COUNT(DISTINCT sample_unique_id)", "mutation_wes_coverage",
+                     "mutation_status != 'UNCALLED'", "off_panel = 0",
+                     "same sample set"):
+        assert required in guide, required
+
+
+def test_frequency_guide_warns_the_error_runs_both_ways():
+    """A number below the UI is not evidence of a conservative estimate."""
+    guide = server._mutation_frequency_guide_text()
+    assert "errors run in both directions" in guide


### PR DESCRIPTION
Addresses #53 (three reports: Tali Mazor 2026-05-15, 2026-05-28, 2026-06-01).

## What was missing

`mutation-frequency-guide.md` already tells the agent to use gene-specific denominators, and the STOP rule already catches impossible results. But the STOP rule only fires **above 100%**, and the reported failure is the opposite case: a frequency that looks entirely reasonable and is still wrong. There was nothing in the guide naming the ground truth, and nothing to do when a user says "this does not match the UI".

## Ground truth

The study view computes `numberOfAlteredCases / numberOfProfiledCases`, served by `POST /api/mutated-genes/fetch`. Two of that endpoint's fields are traps, and both are now documented:

**`totalCount` is mutation events, not samples.** In `glioma_mskcc_2019`, **268 of 485 genes** have more events than altered samples — so `COUNT(*)` is wrong for the majority of genes, not for an unlucky few. TP53 has 511 events across 405 samples: 50.9% instead of 40.3%.

**`numberOfProfiledCases` is per-gene.** That one study takes **10 distinct denominator values, from 45 to 1,004**. TERT is profiled in 882 of 1,004 samples, so a study-wide denominator gives 62.1% instead of 68.5%.

| gene | altered samples | profiled for gene | events | study view | `totalCount` / 1004 |
|---|--:|--:|--:|--:|--:|
| TERT | 604 | **882** | 623 | **68.5%** | 62.1% |
| TP53 | 405 | 1004 | 511 | **40.3%** | 50.9% |
| EGFR | 146 | 1004 | 197 | **14.5%** | 19.6% |
| ATRX | 222 | 1004 | 255 | **22.1%** | 25.4% |

Every figure above was pulled from `https://www.cbioportal.org/api/mutated-genes/fetch` and re-verified before committing. The guide also notes the error runs in **both directions** — a number below the UI is not evidence of a conservative estimate, which is worth saying explicitly because that is the intuition that stops people from checking.

This also explains the off-by-one in the 2026-05-28 report (811 vs 812 profiled): the profiled denominator is a per-gene, panel-derived quantity, so it is exactly the kind of number that lands one off when the WES branch or a panel row is handled slightly differently — not a rounding artifact.

## Reconciliation procedure

Five ordered checks, so a mismatch report becomes a diagnosis instead of a defence:

1. Numerator is `COUNT(DISTINCT sample_unique_id)`, never `COUNT(*)` or `SUM`.
2. Denominator from `sample_to_gene_panel_derived` for that gene, unioned with `mutation_wes_coverage` (the existing STOP rule explains why the WES branch is mandatory).
3. `mutation_status != 'UNCALLED'` and `off_panel = 0` both applied.
4. Numerator and denominator cover the **same sample set** — a cohort filter applied to only one of them produces exactly this symptom.
5. State the counting unit. The study view counts samples.

If the mismatch survives all five, report both numbers rather than picking one.

## Level of the fix

This is guide-level rather than data- or tool-level, deliberately. The SQL views in `4-mutation-frequency-views.sql` already implement the correct arithmetic; the failure is the agent hand-rolling a query and having no way to notice it is wrong. What was absent is a check, not a formula.

The stronger fix would be **tool-level**: a `get_study_view_frequency(study_id, gene)` tool that returns the study view's own numbers so the agent can self-verify instead of being trusted to. I have not done that here because it would give this MCP server an outbound HTTP dependency on a portal API, and that is an architecture call for you rather than something to slip into a guide PR. Happy to implement it if you want it — say which base URL it should read (deployment-configurable, presumably) and I will send it separately.

## Tests

Two cases added to `tests/test_guide_layer_issue_coverage.py`, matching the existing pattern in that file: the reconciliation section and all five steps are present, both field-level traps are stated, and the both-directions warning is pinned.

```
15 passed
```

`ruff` clean on the changed test file. `uv.lock` untouched.