### PR TITLE
Pin fastmcp below 2.14 so a fresh install can import the server

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,10 @@ authors = [
     { name = "cBioPortal MCP Contributors" }
 ]
 dependencies = [
-    "fastmcp",
+    # mcp-clickhouse 0.1.11 passes dependencies= to FastMCP(), removed in fastmcp 2.14.
+    # Without the upper bound a fresh install resolves fastmcp 3.x and every import of
+    # cbioportal_mcp.server fails. Lift this together with the mcp-clickhouse pin below.
+    "fastmcp>=2.10,<2.14",
     # 0.3.0 renamed run_select_query → run_query (breaking change)
     "mcp-clickhouse==0.1.11",
     "clickhouse-driver>=0.2.0",


### PR DESCRIPTION
A clean `uv pip install -e ".[dev]"` currently produces a checkout where **zero tests can be collected**.

## Cause

`fastmcp` is unconstrained in `pyproject.toml`, so a fresh resolve picks 3.x. `mcp-clickhouse==0.1.11` — pinned deliberately, since 0.3.0 renamed `run_select_query` → `run_query` — passes `dependencies=` to `FastMCP()`, and that argument has been removed:

```
TypeError: FastMCP() got unexpected keyword argument(s): 'dependencies'
```

Every test module imports `cbioportal_mcp.server`, so all of them error during collection.

`uv sync` is unaffected, because `uv.lock` already resolves fastmcp 2.10.6. That is why this has not shown up in CI — it only hits contributors who install with pip instead of syncing the lock, and when it does it looks like a broken checkout rather than a resolver artifact. I lost a while to it before checking the lockfile.

## Verified compatibility with mcp-clickhouse 0.1.11

| fastmcp | `import mcp_clickhouse` |
|---|---|
| 2.10.6 (what `uv.lock` pins) | ok |
| 2.12.0 | ok |
| 2.13.0 | ok |
| 2.14.7 | `TypeError` |
| 3.4.4 (current fresh resolve) | `TypeError` |

Each row tested in its own clean venv — downgrading in place leaves stale files and gives misleading results. I did not isolate whether the break lands exactly at 2.14.0 or slightly later in the 2.14 series; `<2.14` is the conservative bound consistent with the data above. Tighten or widen as you prefer.

## Result

```
$ uv pip install -e ".[dev]"     # fresh venv
$ python -c "import fastmcp; print(fastmcp.__version__)"
2.13.3
$ pytest tests/ -q
13 passed
```

The bound carries a comment saying to lift it together with the `mcp-clickhouse` pin, since upgrading that dependency is what actually removes the constraint — otherwise this is the kind of pin that outlives its reason.

`uv.lock` is untouched (2.10.6 still satisfies the new bound, so syncing behaviour does not change).