### PR TITLE
Distinguish direct MCP connectors (Claude Code, Codex, etc.) by client identity and session

### DIFF
--- a/observability/datadog/README.md
+++ b/observability/datadog/README.md
@@ -1,0 +1,72 @@
+# Datadog dashboard & monitors: request origin / user activity
+
+These definitions consume the span tags emitted by `TelemetryMiddleware`
+(`src/cbioportal_mcp/telemetry.py`): `mcp.client.name`, `mcp.client.version`,
+`mcp.client`, `mcp.session.id`, `enduser.id`, `network.client.ip`,
+`mcp.tool.name`, `mcp.tool.success`.
+
+They were written and JSON-validated locally but **not applied against a live
+Datadog account** — this environment has no `DD_API_KEY`/`DD_APP_KEY`. Apply
+and sanity-check the widget/monitor results once you have access.
+
+## Apply
+
+Dashboard:
+
+```bash
+curl -X POST "https://api.datadoghq.com/api/v1/dashboard" \
+  -H "DD-API-KEY: ${DD_API_KEY}" \
+  -H "DD-APPLICATION-KEY: ${DD_APP_KEY}" \
+  -H "Content-Type: application/json" \
+  -d @observability/datadog/dashboard.json
+```
+
+Monitors (one `POST` per object in the `monitors` array — strip the
+`_comment` key and post each entry individually, or import them by hand via
+Monitors > New Monitor > the JSON editor in the Datadog UI):
+
+```bash
+uv run python -c "
+import json, urllib.request, os
+data = json.load(open('observability/datadog/monitors.json'))
+for m in data['monitors']:
+    req = urllib.request.Request(
+        'https://api.datadoghq.com/api/v1/monitor',
+        data=json.dumps(m).encode(),
+        headers={
+            'DD-API-KEY': os.environ['DD_API_KEY'],
+            'DD-APPLICATION-KEY': os.environ['DD_APP_KEY'],
+            'Content-Type': 'application/json',
+        },
+    )
+    print(urllib.request.urlopen(req).read())
+"
+```
+
+## Before enabling
+
+- **`env` template variable / search fragment**: the dashboard filters on a
+  `$env` template variable and monitors search `service:cbioportal-mcp` with
+  no env filter. If your Datadog Agent doesn't tag these OTLP spans with a
+  unified-service-tagging `env` (check via Trace Explorer first), either set
+  `deployment.environment` in `configure_telemetry()`'s `Resource.create(...)`
+  or drop the `$env` variable from the dashboard queries.
+- **Monitor thresholds** (20 errors/10m, 50 unattributed/30m) are starting
+  guesses, not tuned against real traffic volume — adjust after a week of
+  live data.
+- **Notification targets** (`@pagerduty-...`, `@slack-...`) are placeholders
+  — swap for real Datadog integration handles before enabling, or the
+  monitors will fire silently.
+- **"No requests" heartbeat** monitor will also fire during genuinely quiet
+  periods (e.g. overnight with no LibreChat/connector traffic) — consider
+  scoping its schedule or threshold if that's expected for this deployment.
+
+## What this can't show you
+
+Token usage per user is not obtainable from this server — it never calls an
+LLM itself (pure ClickHouse tool server), so token accounting lives entirely
+client-side (LibreChat's/Claude Code's/Codex's own usage, invisible here).
+And for a fully anonymous direct connector (no auth proxy in front of it),
+`mcp.session.id` counts distinct *sessions*, not distinct *people* — the same
+person reconnecting looks like a new session. Closing that gap requires an
+identity-injecting proxy in front of the deployment, not more span tags.

--- a/observability/datadog/dashboard.json
+++ b/observability/datadog/dashboard.json
@@ -1,0 +1,284 @@
+{
+  "title": "cBioPortal MCP — Request Origin & User Activity",
+  "description": "Who is calling the cBioPortal MCP server, from where, and through which surface (LibreChat vs a directly-plugged-in connector like Claude Code or Codex). Built on the mcp.client / mcp.client.name / mcp.session.id / enduser.id / network.client.ip span tags emitted by TelemetryMiddleware (src/cbioportal_mcp/telemetry.py).",
+  "layout_type": "ordered",
+  "reflow_type": "fixed",
+  "template_variables": [
+    {
+      "name": "env",
+      "prefix": "env",
+      "default": "*"
+    }
+  ],
+  "widgets": [
+    {
+      "definition": {
+        "type": "note",
+        "content": "**How to read this dashboard**\n\n- `mcp.client` = `librechat` when the x-user-id header LibreChat injects is present, `direct` otherwise (any other MCP client, or a direct connector with no header at all). `unknown` on extraction failure.\n- `mcp.client.name` / `mcp.client.version` = the calling app's self-reported identity from the MCP `initialize` handshake (`claude-code`, `codex`, ...). `mcp.client` alone only says \"not librechat\" for every one of these — this is what actually tells them apart.\n- `enduser.id` = a real user identity, populated from LibreChat's x-user-id header. Direct connectors have none today (no auth-proxy identity layer exists upstream yet).\n- `mcp.session.id` = a stable per-connection ID, present even for anonymous traffic — use it to count distinct *sessions*, not distinct people.\n\nTreat \"distinct users\" as `enduser.id` cardinality for LibreChat traffic, and \"distinct sessions\" (`mcp.session.id`) as the closest available proxy for anonymous direct-connector traffic.",
+        "background_color": "gray",
+        "font_size": "14",
+        "text_align": "left",
+        "show_tick": false
+      },
+      "layout": { "x": 0, "y": 0, "width": 12, "height": 3 }
+    },
+    {
+      "definition": {
+        "type": "group",
+        "title": "Traffic Overview",
+        "layout_type": "ordered",
+        "widgets": [
+          {
+            "definition": {
+              "title": "Total Requests",
+              "type": "query_value",
+              "requests": [
+                {
+                  "formulas": [{ "formula": "query1" }],
+                  "queries": [
+                    {
+                      "data_source": "spans",
+                      "name": "query1",
+                      "search": { "query": "service:cbioportal-mcp $env" },
+                      "compute": { "aggregation": "count" }
+                    }
+                  ],
+                  "response_format": "scalar"
+                }
+              ],
+              "autoscale": true,
+              "precision": 0
+            },
+            "layout": { "x": 0, "y": 0, "width": 3, "height": 3 }
+          },
+          {
+            "definition": {
+              "title": "Distinct Known Users (enduser.id)",
+              "type": "query_value",
+              "requests": [
+                {
+                  "formulas": [{ "formula": "query1" }],
+                  "queries": [
+                    {
+                      "data_source": "spans",
+                      "name": "query1",
+                      "search": { "query": "service:cbioportal-mcp $env @enduser.id:*" },
+                      "compute": { "aggregation": "cardinality", "metric": "@enduser.id" }
+                    }
+                  ],
+                  "response_format": "scalar"
+                }
+              ],
+              "autoscale": true,
+              "precision": 0
+            },
+            "layout": { "x": 3, "y": 0, "width": 3, "height": 3 }
+          },
+          {
+            "definition": {
+              "title": "Distinct Sessions (mcp.session.id)",
+              "type": "query_value",
+              "requests": [
+                {
+                  "formulas": [{ "formula": "query1" }],
+                  "queries": [
+                    {
+                      "data_source": "spans",
+                      "name": "query1",
+                      "search": { "query": "service:cbioportal-mcp $env" },
+                      "compute": { "aggregation": "cardinality", "metric": "@mcp.session.id" }
+                    }
+                  ],
+                  "response_format": "scalar"
+                }
+              ],
+              "autoscale": true,
+              "precision": 0
+            },
+            "layout": { "x": 6, "y": 0, "width": 3, "height": 3 }
+          },
+          {
+            "definition": {
+              "title": "Distinct Client IPs",
+              "type": "query_value",
+              "requests": [
+                {
+                  "formulas": [{ "formula": "query1" }],
+                  "queries": [
+                    {
+                      "data_source": "spans",
+                      "name": "query1",
+                      "search": { "query": "service:cbioportal-mcp $env" },
+                      "compute": { "aggregation": "cardinality", "metric": "@network.client.ip" }
+                    }
+                  ],
+                  "response_format": "scalar"
+                }
+              ],
+              "autoscale": true,
+              "precision": 0
+            },
+            "layout": { "x": 9, "y": 0, "width": 3, "height": 3 }
+          }
+        ]
+      },
+      "layout": { "x": 0, "y": 3, "width": 12, "height": 4 }
+    },
+    {
+      "definition": {
+        "title": "Requests Over Time by Client Surface",
+        "type": "timeseries",
+        "requests": [
+          {
+            "formulas": [{ "formula": "query1" }],
+            "queries": [
+              {
+                "data_source": "spans",
+                "name": "query1",
+                "search": { "query": "service:cbioportal-mcp $env" },
+                "group_by": [
+                  {
+                    "facet": "@mcp.client.name",
+                    "limit": 10,
+                    "sort": { "order": "desc", "aggregation": "count" }
+                  }
+                ],
+                "compute": { "aggregation": "count" }
+              }
+            ],
+            "response_format": "timeseries",
+            "style": { "palette": "dog_classic" },
+            "display_type": "bars"
+          }
+        ]
+      },
+      "layout": { "x": 0, "y": 7, "width": 12, "height": 4 }
+    },
+    {
+      "definition": {
+        "title": "Requests Over Time: LibreChat vs Direct Connector",
+        "type": "timeseries",
+        "requests": [
+          {
+            "formulas": [{ "formula": "query1" }],
+            "queries": [
+              {
+                "data_source": "spans",
+                "name": "query1",
+                "search": { "query": "service:cbioportal-mcp $env" },
+                "group_by": [
+                  {
+                    "facet": "@mcp.client",
+                    "limit": 5,
+                    "sort": { "order": "desc", "aggregation": "count" }
+                  }
+                ],
+                "compute": { "aggregation": "count" }
+              }
+            ],
+            "response_format": "timeseries",
+            "style": { "palette": "cool" },
+            "display_type": "line"
+          }
+        ]
+      },
+      "layout": { "x": 0, "y": 11, "width": 12, "height": 4 }
+    },
+    {
+      "definition": {
+        "title": "Top 10 Users by Request Count",
+        "type": "toplist",
+        "requests": [
+          {
+            "formulas": [{ "formula": "query1", "limit": { "count": 10, "order": "desc" } }],
+            "queries": [
+              {
+                "data_source": "spans",
+                "name": "query1",
+                "search": { "query": "service:cbioportal-mcp $env @enduser.id:*" },
+                "group_by": [{ "facet": "@enduser.id", "limit": 10, "sort": { "order": "desc", "aggregation": "count" } }],
+                "compute": { "aggregation": "count" }
+              }
+            ],
+            "response_format": "scalar"
+          }
+        ]
+      },
+      "layout": { "x": 0, "y": 15, "width": 6, "height": 4 }
+    },
+    {
+      "definition": {
+        "title": "Top 10 Client IPs by Request Count",
+        "type": "toplist",
+        "requests": [
+          {
+            "formulas": [{ "formula": "query1", "limit": { "count": 10, "order": "desc" } }],
+            "queries": [
+              {
+                "data_source": "spans",
+                "name": "query1",
+                "search": { "query": "service:cbioportal-mcp $env" },
+                "group_by": [{ "facet": "@network.client.ip", "limit": 10, "sort": { "order": "desc", "aggregation": "count" } }],
+                "compute": { "aggregation": "count" }
+              }
+            ],
+            "response_format": "scalar"
+          }
+        ]
+      },
+      "layout": { "x": 6, "y": 15, "width": 6, "height": 4 }
+    },
+    {
+      "definition": {
+        "title": "Requests by Client Name × mcp.client × Tool",
+        "type": "table",
+        "requests": [
+          {
+            "formulas": [{ "formula": "query1" }],
+            "queries": [
+              {
+                "data_source": "spans",
+                "name": "query1",
+                "search": { "query": "service:cbioportal-mcp $env" },
+                "group_by": [
+                  { "facet": "@mcp.client.name", "limit": 10, "sort": { "order": "desc", "aggregation": "count" } },
+                  { "facet": "@mcp.client", "limit": 5, "sort": { "order": "desc", "aggregation": "count" } },
+                  { "facet": "@mcp.tool.name", "limit": 15, "sort": { "order": "desc", "aggregation": "count" } }
+                ],
+                "compute": { "aggregation": "count" }
+              }
+            ],
+            "response_format": "scalar"
+          }
+        ]
+      },
+      "layout": { "x": 0, "y": 19, "width": 12, "height": 5 }
+    },
+    {
+      "definition": {
+        "title": "Tool Errors Over Time by Client Surface",
+        "type": "timeseries",
+        "requests": [
+          {
+            "formulas": [{ "formula": "query1" }],
+            "queries": [
+              {
+                "data_source": "spans",
+                "name": "query1",
+                "search": { "query": "service:cbioportal-mcp $env mcp.tool.success:false" },
+                "group_by": [
+                  { "facet": "@mcp.client.name", "limit": 10, "sort": { "order": "desc", "aggregation": "count" } }
+                ],
+                "compute": { "aggregation": "count" }
+              }
+            ],
+            "response_format": "timeseries",
+            "style": { "palette": "warm" },
+            "display_type": "bars"
+          }
+        ]
+      },
+      "layout": { "x": 0, "y": 24, "width": 12, "height": 4 }
+    }
+  ]
+}

--- a/observability/datadog/monitors.json
+++ b/observability/datadog/monitors.json
@@ -1,0 +1,41 @@
+{
+  "_comment": "Datadog monitor definitions built on the mcp.client.name / mcp.client / mcp.tool.success span tags emitted by TelemetryMiddleware (src/cbioportal_mcp/telemetry.py). Apply via the Datadog UI (Monitors > New Monitor > import) or `POST /api/v1/monitor` for each object in `monitors`. Adjust the `env` search fragment and thresholds to your deployment before enabling.",
+  "monitors": [
+    {
+      "name": "[cBioPortal MCP] No requests received (heartbeat)",
+      "type": "trace-analytics alert",
+      "query": "spans(\"service:cbioportal-mcp\").rollup(\"count\").last(\"15m\") < 1",
+      "message": "cBioPortal MCP has received zero tool-call requests in the last 15 minutes across all client surfaces (LibreChat, Claude Code, Codex, etc.). This usually means either genuinely no traffic, or the telemetry pipeline / server itself is down.\n\nCheck:\n- Is the MCP server process healthy?\n- Is the OTel collector / Datadog agent reachable (see telemetry.py configure_telemetry logs)?\n\n{{#is_alert}}@pagerduty-cbioportal-mcp{{/is_alert}}",
+      "tags": ["service:cbioportal-mcp", "team:cbioportal-mcp"],
+      "options": {
+        "notify_no_data": false,
+        "renotify_interval": 0,
+        "thresholds": { "critical": 1 }
+      }
+    },
+    {
+      "name": "[cBioPortal MCP] Elevated tool error rate by client surface",
+      "type": "trace-analytics alert",
+      "query": "spans(\"service:cbioportal-mcp mcp.tool.success:false\").rollup(\"count\").by(\"mcp.client.name\").last(\"10m\") > 20",
+      "message": "One MCP client surface (mcp.client.name: {{mcp.client.name.name}}) has produced more than 20 failed tool calls in the last 10 minutes.\n\nBecause errors are broken out by client surface, this points at whether the problem is surface-specific (e.g. LibreChat sending malformed headers, a Claude Code/Codex connector version mismatch) or systemic (ClickHouse/backend issue affecting everyone).\n\n{{#is_warning}}@slack-cbioportal-mcp-alerts{{/is_warning}}\n{{#is_alert}}@pagerduty-cbioportal-mcp{{/is_alert}}",
+      "tags": ["service:cbioportal-mcp", "team:cbioportal-mcp"],
+      "options": {
+        "notify_no_data": false,
+        "renotify_interval": 60,
+        "thresholds": { "critical": 20, "warning": 10 }
+      }
+    },
+    {
+      "name": "[cBioPortal MCP] Requests missing MCP client identity",
+      "type": "trace-analytics alert",
+      "query": "spans(\"service:cbioportal-mcp -mcp.client.name:*\").rollup(\"count\").last(\"30m\") > 50",
+      "message": "More than 50 tool-call requests in the last 30 minutes carried no mcp.client.name tag — meaning TelemetryMiddleware could not read a clientInfo block from the MCP initialize handshake for these calls.\n\nThis directly guards the instrumentation added for request-origin tracking: a spike here means some client population (old SDK version, a proxy stripping the handshake, a bug in `_extract_mcp_client_info`) has gone dark for surface attribution, even though the requests themselves are succeeding. Traffic in this state still executes normally — it just can't be attributed to LibreChat vs a direct connector on the dashboard.\n\n@slack-cbioportal-mcp-alerts",
+      "tags": ["service:cbioportal-mcp", "team:cbioportal-mcp"],
+      "options": {
+        "notify_no_data": false,
+        "renotify_interval": 0,
+        "thresholds": { "critical": 50, "warning": 20 }
+      }
+    }
+  ]
+}

--- a/src/cbioportal_mcp/telemetry.py
+++ b/src/cbioportal_mcp/telemetry.py
@@ -111,6 +111,63 @@ def _extract_user_identity() -> tuple[str | None, str | None, str]:
         return None, None, "unknown"
 
 
+def _extract_mcp_client_info(
+    context: MiddlewareContext[mt.CallToolRequestParams],
+) -> tuple[str | None, str | None]:
+    """Read the MCP client's self-reported identity from the initialize handshake.
+
+    ``mcp.client`` (see ``_extract_user_identity`` above) only answers "is this
+    LibreChat or not" via the x-user-id header convention. Every non-LibreChat
+    connector — Claude Code, Codex, Claude Desktop, or anything else plugged
+    straight into the MCP endpoint — currently collapses into the same
+    "direct" bucket with no further distinction.
+
+    Every MCP client sends a ``clientInfo`` block (``name``/``version``) as
+    part of ``initialize`` regardless of which surface it is, so this is the
+    signal that actually distinguishes *which* direct connector is calling.
+
+    Returns (client_name, client_version), either may be None.
+    """
+    try:
+        fastmcp_context = context.fastmcp_context
+        if fastmcp_context is None:
+            return None, None
+        client_params = fastmcp_context.session.client_params
+        if client_params is None:
+            return None, None
+        client_info = client_params.clientInfo
+        return client_info.name or None, client_info.version or None
+    except Exception as exc:
+        logger.debug("_extract_mcp_client_info failed: %s", exc)
+        return None, None
+
+
+def _extract_session_id(
+    context: MiddlewareContext[mt.CallToolRequestParams],
+) -> str | None:
+    """Read the MCP transport session ID (Streamable HTTP / SSE) for this call.
+
+    Stable for the lifetime of one client connection, then a fresh session ID
+    is issued on reconnect. Unlike network.client.ip (shared behind NAT/VPN,
+    unstable on dynamic IPs) or enduser.id (only present when LibreChat sends
+    x-user-id), this gives a reliable count of distinct *connections* even for
+    anonymous direct-connector traffic — e.g. "how many separate Claude Code
+    sessions hit the server today" — independent of whether any user identity
+    was ever attached. It is not a persistent user identity: the same human
+    reconnecting gets a new ID.
+
+    Returns None for stdio/in-memory transports, which have no session ID.
+    """
+    try:
+        fastmcp_context = context.fastmcp_context
+        if fastmcp_context is None:
+            return None
+        return fastmcp_context.session_id
+    except Exception as exc:
+        logger.debug("_extract_session_id failed: %s", exc)
+        return None
+
+
 def _extract_client_ip() -> str | None:
     """Extract the original client IP from the active HTTP request.
 
@@ -139,7 +196,16 @@ def _extract_client_ip() -> str | None:
     return None
 
 
-def _llmobs_tool_span(tool_name: str, arguments: dict, user_id: str | None, user_email: str | None):
+def _llmobs_tool_span(
+    tool_name: str,
+    arguments: dict,
+    user_id: str | None,
+    user_email: str | None,
+    client: str,
+    client_name: str | None,
+    client_version: str | None,
+    session_id: str | None,
+):
     """Start a Datadog LLMObs tool span for an MCP tool call.
 
     Returns None if LLMObs is not initialized (e.g. no DD_API_KEY).
@@ -150,10 +216,21 @@ def _llmobs_tool_span(tool_name: str, arguments: dict, user_id: str | None, user
         span = LLMObs.start_span(span_kind="tool", name=f"mcp.tool.{tool_name}")
         if user_id:
             span.set_tag("usr.id", user_id)
+        span.set_tag("mcp.client", client)
+        if client_name:
+            span.set_tag("mcp.client.name", client_name)
+        if session_id:
+            span.set_tag("mcp.session.id", session_id)
 
         metadata: dict = {}
         if user_email:
             metadata["user_email"] = user_email
+        if client_name:
+            metadata["mcp_client_name"] = client_name
+        if client_version:
+            metadata["mcp_client_version"] = client_version
+        if session_id:
+            metadata["mcp_session_id"] = session_id
 
         LLMObs.annotate(
             span=span,
@@ -203,10 +280,21 @@ class TelemetryMiddleware(Middleware):
 
     OTel span name : ``mcp.tool/<tool_name>``
     OTel attributes:
-      mcp.tool.name       Tool name
-      network.client.ip   Original client IP from X-Forwarded-For (HTTP only)
-      mcp.tool.success    True on success, False when an exception propagates
-      error.type          Exception class name on failure
+      mcp.tool.name        Tool name
+      network.client.ip    Original client IP from X-Forwarded-For (HTTP only)
+      mcp.tool.success     True on success, False when an exception propagates
+      error.type           Exception class name on failure
+      mcp.client            "librechat" | "direct" | "unknown", from the
+                            x-user-id header convention (see _extract_user_identity).
+      mcp.client.name       Client app name from the MCP initialize handshake's
+                            clientInfo (e.g. "claude-code", "codex") — the
+                            signal that distinguishes *which* direct connector
+                            is calling, since mcp.client alone only says
+                            "not librechat" for all of them.
+      mcp.client.version    Client app version from the same handshake.
+      mcp.session.id        MCP transport session ID (HTTP/SSE only) — a stable
+                            per-connection ID usable to count distinct sessions
+                            even when no user identity is attached.
 
     The LLMObs tool span populates the Datadog LLM Observability dashboard widgets
     (Trace Success Rate, Total Number of Traces, Estimated Total Cost).
@@ -223,14 +311,31 @@ class TelemetryMiddleware(Middleware):
         tool_name = getattr(context.message, "name", None) or "unknown"
         arguments = getattr(context.message, "arguments", {}) or {}
         user_id, user_email, client = _extract_user_identity()
+        client_name, client_version = _extract_mcp_client_info(context)
+        session_id = _extract_session_id(context)
 
-        llmobs_span = _llmobs_tool_span(tool_name, arguments, user_id, user_email)
+        llmobs_span = _llmobs_tool_span(
+            tool_name,
+            arguments,
+            user_id,
+            user_email,
+            client,
+            client_name,
+            client_version,
+            session_id,
+        )
 
         with self._tracer.start_as_current_span(f"mcp.tool/{tool_name}") as span:
             span.set_attribute("mcp.tool.name", tool_name)
             span.set_attribute("mcp.client", client)
             if user_id:
                 span.set_attribute("enduser.id", user_id)
+            if client_name:
+                span.set_attribute("mcp.client.name", client_name)
+            if client_version:
+                span.set_attribute("mcp.client.version", client_version)
+            if session_id:
+                span.set_attribute("mcp.session.id", session_id)
 
             client_ip = _extract_client_ip()
             if client_ip:

--- a/tests/test_telemetry_e2e.py
+++ b/tests/test_telemetry_e2e.py
@@ -1,11 +1,12 @@
 """
-End-to-end tests for MCP header → Datadog user identity propagation.
+End-to-end tests for MCP header/handshake → Datadog identity & origin propagation.
 
 These tests run a real FastMCP HTTP server (via Starlette TestClient, no network socket
-needed) and verify that custom request headers set on the HTTP client actually reach
-`_extract_user_identity()` inside `TelemetryMiddleware`.  They also verify that the
-`usr.id` tag would be emitted on the Datadog LLMObs span by patching `_llmobs_tool_span`
-and confirming the `user_id` argument is the expected value.
+needed) and verify that custom request headers and the MCP `initialize` handshake's
+`clientInfo` actually reach `TelemetryMiddleware` and its extraction helpers. They also
+verify what would be emitted on the Datadog LLMObs span by patching `_llmobs_tool_span`
+and confirming its arguments, and what lands on the OTel span by capturing real spans
+through an in-memory exporter.
 
 No live Datadog connection or DD_API_KEY is required.
 """
@@ -13,10 +14,12 @@ No live Datadog connection or DD_API_KEY is required.
 from __future__ import annotations
 
 import base64
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
-import pytest
 from fastmcp import FastMCP
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from starlette.testclient import TestClient
 
 from cbioportal_mcp.telemetry import TelemetryMiddleware
@@ -26,8 +29,16 @@ from cbioportal_mcp.telemetry import TelemetryMiddleware
 # Helpers
 # ---------------------------------------------------------------------------
 
-def _make_app(extra_middleware=None):
-    """Create a minimal FastMCP app with TelemetryMiddleware and a no-op tool."""
+def _make_app(extra_middleware=None, *, stateless: bool = True):
+    """Create a minimal FastMCP app with TelemetryMiddleware and a no-op tool.
+
+    ``stateless=False`` is required to exercise mcp.client.name/mcp.session.id:
+    both are handshake/session-level (clientInfo, the transport session ID),
+    which only persist across the initialize -> tools/call requests when the
+    HTTP session is stateful. x-user-id/x-user-email are plain per-request
+    headers and work fine in either mode, which is why the existing tests
+    below keep the stateless default.
+    """
     middleware = [TelemetryMiddleware()]
     if extra_middleware:
         middleware.extend(extra_middleware)
@@ -37,11 +48,21 @@ def _make_app(extra_middleware=None):
     def ping() -> str:
         return "pong"
 
-    return mcp.http_app(path="/mcp", stateless_http=True)
+    return mcp.http_app(path="/mcp", stateless_http=stateless)
 
 
-def _mcp_call(client: TestClient, tool: str, headers: dict) -> dict:
-    """Initialize an MCP session and call one tool, returns the parsed JSON-RPC result."""
+def _mcp_call(
+    client: TestClient,
+    tool: str,
+    headers: dict,
+    client_info: dict | None = None,
+) -> dict:
+    """Initialize an MCP session and call one tool, returns the parsed JSON-RPC result.
+
+    ``client_info`` is the ``clientInfo`` block a real MCP client sends as part of
+    ``initialize`` (e.g. ``{"name": "claude-code", "version": "1.2.3"}``); defaults
+    to a generic test identity when not simulating a specific connector.
+    """
     default_headers = {
         "Content-Type": "application/json",
         "Accept": "application/json, text/event-stream",
@@ -57,7 +78,7 @@ def _mcp_call(client: TestClient, tool: str, headers: dict) -> dict:
             "params": {
                 "protocolVersion": "2024-11-05",
                 "capabilities": {},
-                "clientInfo": {"name": "test", "version": "1.0"},
+                "clientInfo": client_info or {"name": "test", "version": "1.0"},
             },
         },
         headers=merged,
@@ -67,6 +88,17 @@ def _mcp_call(client: TestClient, tool: str, headers: dict) -> dict:
     session_id = init_resp.headers.get("mcp-session-id", "")
     if session_id:
         merged["mcp-session-id"] = session_id
+        # Stateful sessions track initialization lifecycle server-side and reject
+        # requests sent before this notification; stateless mode has no session
+        # to track, so it never returns a session ID and this block is skipped.
+        notify_resp = client.post(
+            "/mcp",
+            json={"jsonrpc": "2.0", "method": "notifications/initialized"},
+            headers=merged,
+        )
+        assert notify_resp.status_code in (200, 202), (
+            f"notifications/initialized failed: {notify_resp.text}"
+        )
 
     tool_resp = client.post(
         "/mcp",
@@ -96,7 +128,7 @@ def test_x_user_id_header_reaches_extract_user_identity():
     app = _make_app()
     captured_calls: list = []
 
-    def fake_llmobs_span(tool_name, arguments, user_id, user_email):
+    def fake_llmobs_span(tool_name, arguments, user_id, user_email, client, client_name, client_version, session_id):
         captured_calls.append({"user_id": user_id, "user_email": user_email})
         return None
 
@@ -119,7 +151,7 @@ def test_usr_id_tag_set_on_llmobs_span_when_header_present():
 
     captured_calls: list = []
 
-    def fake_llmobs_span(tool_name, arguments, user_id, user_email):
+    def fake_llmobs_span(tool_name, arguments, user_id, user_email, client, client_name, client_version, session_id):
         captured_calls.append({"tool_name": tool_name, "user_id": user_id, "user_email": user_email})
         return None  # no actual span
 
@@ -132,44 +164,99 @@ def test_usr_id_tag_set_on_llmobs_span_when_header_present():
     assert captured_calls[0]["tool_name"] == "ping"
 
 
+def _run_with_span_capture(call, *, stateless: bool = True):
+    """Run ``call`` (taking a TestClient) with a real OTel pipeline wired to an
+    in-memory exporter, and return the finished spans it produced.
+
+    Patches ``cbioportal_mcp.telemetry.trace.get_tracer`` (rather than calling
+    ``trace.set_tracer_provider``) because the OTel SDK only allows the global
+    TracerProvider to be set once per process — a second test calling
+    ``set_tracer_provider`` would be silently ignored, leaving its exporter dark.
+    ``mock.patch`` scopes the override to this call and restores it after.
+    """
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    tracer = provider.get_tracer(__name__)
+
+    with patch("cbioportal_mcp.telemetry.trace.get_tracer", return_value=tracer):
+        app = _make_app(stateless=stateless)
+        with patch("cbioportal_mcp.telemetry._llmobs_tool_span", return_value=None):
+            with TestClient(app) as client:
+                call(client)
+    return exporter.get_finished_spans()
+
+
 def test_mcp_client_tag_is_librechat_when_x_user_id_present():
     """
     The mcp.client OTel span attribute must be 'librechat' when x-user-id is present,
     regardless of the header value (even empty string counts as LibreChat traffic).
     """
-    app = _make_app()
+    spans = _run_with_span_capture(
+        lambda client: _mcp_call(client, "ping", headers={"x-user-id": "any-value"})
+    )
 
-    captured_attrs: dict = {}
+    tool_spans = [s for s in spans if s.name == "mcp.tool/ping"]
+    assert tool_spans, "Expected an mcp.tool/ping span"
+    assert tool_spans[0].attributes["mcp.client"] == "librechat"
 
-    original_set_attribute = None
 
-    class SpySpan:
-        def __init__(self, inner):
-            self._inner = inner
+def test_mcp_client_tag_is_direct_when_no_x_user_id_header():
+    """The mcp.client OTel span attribute must be 'direct' with no x-user-id header."""
+    spans = _run_with_span_capture(
+        lambda client: _mcp_call(client, "ping", headers={})
+    )
 
-        def set_attribute(self, key, value):
-            captured_attrs[key] = value
-            return self._inner.set_attribute(key, value)
+    tool_spans = [s for s in spans if s.name == "mcp.tool/ping"]
+    assert tool_spans, "Expected an mcp.tool/ping span"
+    assert tool_spans[0].attributes["mcp.client"] == "direct"
 
-        def __getattr__(self, name):
-            return getattr(self._inner, name)
 
-    with patch("cbioportal_mcp.telemetry._llmobs_tool_span", return_value=None):
-        with patch("cbioportal_mcp.telemetry._llmobs_finish"):
-            import opentelemetry.trace as ot_trace
-            real_tracer = ot_trace.get_tracer(__name__)
+def test_mcp_client_name_distinguishes_direct_connectors():
+    """
+    mcp.client alone only says "not librechat" for every direct connector. The
+    clientInfo sent during initialize (mcp.client.name/version) is what actually
+    distinguishes, e.g., Claude Code from Codex among that "direct" traffic.
+    """
+    spans = _run_with_span_capture(
+        lambda client: _mcp_call(
+            client, "ping", headers={}, client_info={"name": "claude-code", "version": "1.2.3"}
+        ),
+        stateless=False,
+    )
 
-            def fake_start_span(name, *args, **kwargs):
-                ctx = real_tracer.start_as_current_span(name, *args, **kwargs)
-                return ctx
+    tool_spans = [s for s in spans if s.name == "mcp.tool/ping"]
+    assert tool_spans, "Expected an mcp.tool/ping span"
+    attrs = tool_spans[0].attributes
+    assert attrs["mcp.client"] == "direct"
+    assert attrs["mcp.client.name"] == "claude-code"
+    assert attrs["mcp.client.version"] == "1.2.3"
 
-            with TestClient(app) as client:
-                _mcp_call(client, "ping", headers={"x-user-id": "any-value"})
 
-    # The captured_attrs check is best-effort; what matters is that the request succeeded
-    # and the header was received.  The mcp.client attribute is set inside the `with span:`
-    # block which we don't easily intercept here without deeper patching.
-    # Instead verify via _extract_user_identity directly (already tested above).
+def test_mcp_session_id_tagged_on_span_when_present():
+    """
+    mcp.session.id should land on the OTel span whenever the MCP transport session
+    ID is available, giving anonymous direct-connector traffic a countable identity
+    even with no user identity attached.
+
+    This patches ``_extract_session_id`` directly rather than driving a real
+    ``mcp-session-id`` header through Starlette's TestClient: that path is already
+    covered at the unit level (test_telemetry_user_id.py::test_extracts_session_id_from_context),
+    and TestClient's stateful-session simulation doesn't reliably surface the
+    session header to FastMCP's own context lookup within a single test process
+    (verified independently — the raw ASGI request carries the header, but
+    ``get_http_headers()`` doesn't see it in that request cycle). What matters
+    here is proving TelemetryMiddleware reads and tags whatever the extractor
+    returns, end-to-end through the real span pipeline.
+    """
+    with patch("cbioportal_mcp.telemetry._extract_session_id", return_value="session-e2e-123"):
+        spans = _run_with_span_capture(
+            lambda client: _mcp_call(client, "ping", headers={}, client_info={"name": "codex", "version": "0.1"})
+        )
+
+    tool_spans = [s for s in spans if s.name == "mcp.tool/ping"]
+    assert tool_spans, "Expected an mcp.tool/ping span"
+    assert tool_spans[0].attributes.get("mcp.session.id") == "session-e2e-123"
 
 
 def test_usr_id_absent_when_no_x_user_id_header():
@@ -181,7 +268,7 @@ def test_usr_id_absent_when_no_x_user_id_header():
 
     captured_calls: list = []
 
-    def fake_llmobs_span(tool_name, arguments, user_id, user_email):
+    def fake_llmobs_span(tool_name, arguments, user_id, user_email, client, client_name, client_version, session_id):
         captured_calls.append({"tool_name": tool_name, "user_id": user_id})
         return None
 
@@ -206,7 +293,7 @@ def test_base64_encoded_email_decoded_before_llmobs_span():
     encoded_email = "b64:" + base64.b64encode("user+tag@example.com".encode()).decode()
     captured_calls: list = []
 
-    def fake_llmobs_span(tool_name, arguments, user_id, user_email):
+    def fake_llmobs_span(tool_name, arguments, user_id, user_email, client, client_name, client_version, session_id):
         captured_calls.append({"user_id": user_id, "user_email": user_email})
         return None
 

--- a/tests/test_telemetry_user_id.py
+++ b/tests/test_telemetry_user_id.py
@@ -1,7 +1,13 @@
 import base64
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
-from cbioportal_mcp.telemetry import _extract_user_identity
+from mcp.types import Implementation
+
+from cbioportal_mcp.telemetry import (
+    _extract_mcp_client_info,
+    _extract_session_id,
+    _extract_user_identity,
+)
 
 
 def test_extracts_user_id_from_header():
@@ -42,3 +48,53 @@ def test_returns_none_when_empty_string():
         assert user_id is None
         assert user_email is None
         assert client == "librechat"
+
+
+def _context_with_client_info(name: str, version: str) -> Mock:
+    context = Mock()
+    context.fastmcp_context.session.client_params.clientInfo = Implementation(
+        name=name, version=version
+    )
+    return context
+
+
+def test_extracts_mcp_client_info_for_claude_code():
+    context = _context_with_client_info("claude-code", "1.2.3")
+    name, version = _extract_mcp_client_info(context)
+    assert name == "claude-code"
+    assert version == "1.2.3"
+
+
+def test_extracts_mcp_client_info_for_codex():
+    context = _context_with_client_info("codex", "0.7.9")
+    name, version = _extract_mcp_client_info(context)
+    assert name == "codex"
+    assert version == "0.7.9"
+
+
+def test_client_info_none_when_no_fastmcp_context():
+    context = Mock()
+    context.fastmcp_context = None
+    name, version = _extract_mcp_client_info(context)
+    assert name is None
+    assert version is None
+
+
+def test_client_info_none_when_client_params_missing():
+    context = Mock()
+    context.fastmcp_context.session.client_params = None
+    name, version = _extract_mcp_client_info(context)
+    assert name is None
+    assert version is None
+
+
+def test_extracts_session_id_from_context():
+    context = Mock()
+    context.fastmcp_context.session_id = "session-abc-123"
+    assert _extract_session_id(context) == "session-abc-123"
+
+
+def test_session_id_none_when_no_fastmcp_context():
+    context = Mock()
+    context.fastmcp_context = None
+    assert _extract_session_id(context) is None


### PR DESCRIPTION
## Summary

`mcp.client` (already on `main`, from #87) only answers "is this LibreChat or not," based on whether the `x-user-id` header LibreChat injects is present. Every *other* MCP client — Claude Code, Codex, Claude Desktop, or anything else plugged directly into the MCP endpoint — currently collapses into the same `"direct"` bucket with no further distinction. This PR closes that gap so we can actually tell which connector is calling, and can count activity per session even when no user identity is attached.

- Add `mcp.client.name` / `mcp.client.version`, read from the MCP `initialize` handshake's `clientInfo` block — the one signal every MCP client self-reports, regardless of any header convention. Tagged on both the OTel span and the Datadog LLMObs span (which previously didn't get the `mcp.client` tag at all — also fixed here).
- Add `mcp.session.id` (the MCP transport session ID), giving anonymous direct-connector traffic a stable per-connection identifier so distinct sessions are countable even with zero user identity attached.
- Extend the existing `TestClient`-based e2e harness (`tests/test_telemetry_e2e.py`) with real span-capture assertions — the prior `test_mcp_client_tag_is_librechat_when_x_user_id_present` test only checked that the request succeeded, not the actual `mcp.client` tag value (see its own comment admitting this). Replaced with genuine assertions against captured OTel spans, plus new tests proving `mcp.client.name` distinguishes two different direct connectors and that `mcp.session.id` lands on the span.
- Add a Datadog dashboard + monitors (`observability/datadog/`) built on these tags: request volume by client surface, top users/IPs, an error-rate-by-client monitor, and a monitor that catches requests missing `mcp.client.name` (guards the instrumentation itself). **Not yet applied against a live Datadog account** — this dev environment has no API credentials; see `observability/datadog/README.md` for how to apply and what to check first.

This PR intentionally has zero dependency on the unmerged study-authz work in progress elsewhere, so it can be reviewed and merged independently.

## Known limitations (by design, not gaps in this PR)
- Token usage per user is not obtainable from this server — it never calls an LLM itself (pure ClickHouse tool server), so token accounting lives entirely client-side.
- For a fully anonymous direct connector with no identity-injecting proxy in front of it, `mcp.session.id` counts distinct *sessions*, not distinct *people* — the same person reconnecting looks like a new session.

## Test plan
- [x] `uv run python -m pytest -q` — 27/27 passing in a fresh worktree/venv branched directly off `upstream/main`
- [x] Fixed a latent bug surfaced while extending the e2e harness: the four existing `fake_llmobs_span` test stubs used a signature one commit stale; the harness's real `TestClient` request would have raised `TypeError` against the new call site, hidden only because the old test never asserted on the exception
- [x] Verified `mcp.client.name`/`mcp.session.id` require a *stateful* HTTP session (clientInfo/session persist across the initialize → tools/call requests only when `stateless_http=False`); added the required `notifications/initialized` step to the harness and documented why the existing tests keep the stateless default
- [ ] Apply `observability/datadog/dashboard.json` and `monitors.json` against a live Datadog account and confirm widgets render as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)