### PR TITLE
fix: rename mcp.client to mcp.client_kind to avoid Datadog attribute collision

### DIFF
--- a/observability/datadog/README.md
+++ b/observability/datadog/README.md
@@ -2,7 +2,7 @@
 
 These definitions consume the span tags emitted by `TelemetryMiddleware`
 (`src/cbioportal_mcp/telemetry.py`): `mcp.client.name`, `mcp.client.version`,
-`mcp.client`, `mcp.session.id`, `enduser.id`, `network.client.ip`,
+`mcp.client_kind`, `mcp.session.id`, `enduser.id`, `network.client.ip`,
 `mcp.tool.name`, `mcp.tool.success`.
 
 They were written and JSON-validated locally but **not applied against a live

--- a/observability/datadog/dashboard.json
+++ b/observability/datadog/dashboard.json
@@ -1,6 +1,6 @@
 {
   "title": "cBioPortal MCP — Request Origin & User Activity",
-  "description": "Who is calling the cBioPortal MCP server, from where, and through which surface (LibreChat vs a directly-plugged-in connector like Claude Code or Codex). Built on the mcp.client / mcp.client.name / mcp.session.id / enduser.id / network.client.ip span tags emitted by TelemetryMiddleware (src/cbioportal_mcp/telemetry.py).",
+  "description": "Who is calling the cBioPortal MCP server, from where, and through which surface (LibreChat vs a directly-plugged-in connector like Claude Code or Codex). Built on the mcp.client_kind / mcp.client.name / mcp.session.id / enduser.id / network.client.ip span tags emitted by TelemetryMiddleware (src/cbioportal_mcp/telemetry.py).",
   "layout_type": "ordered",
   "reflow_type": "fixed",
   "template_variables": [
@@ -14,7 +14,7 @@
     {
       "definition": {
         "type": "note",
-        "content": "**How to read this dashboard**\n\n- `mcp.client` = `librechat` when the x-user-id header LibreChat injects is present, `direct` otherwise (any other MCP client, or a direct connector with no header at all). `unknown` on extraction failure.\n- `mcp.client.name` / `mcp.client.version` = the calling app's self-reported identity from the MCP `initialize` handshake (`claude-code`, `codex`, ...). `mcp.client` alone only says \"not librechat\" for every one of these — this is what actually tells them apart.\n- `enduser.id` = a real user identity, populated from LibreChat's x-user-id header. Direct connectors have none today (no auth-proxy identity layer exists upstream yet).\n- `mcp.session.id` = a stable per-connection ID, present even for anonymous traffic — use it to count distinct *sessions*, not distinct people.\n\nTreat \"distinct users\" as `enduser.id` cardinality for LibreChat traffic, and \"distinct sessions\" (`mcp.session.id`) as the closest available proxy for anonymous direct-connector traffic.",
+        "content": "**How to read this dashboard**\n\n- `mcp.client_kind` = `librechat` when the x-user-id header LibreChat injects is present, `direct` otherwise (any other MCP client, or a direct connector with no header at all). `unknown` on extraction failure.\n- `mcp.client.name` / `mcp.client.version` = the calling app's self-reported identity from the MCP `initialize` handshake (`claude-code`, `codex`, ...). `mcp.client_kind` alone only says \"not librechat\" for every one of these — this is what actually tells them apart.\n- `enduser.id` = a real user identity, populated from LibreChat's x-user-id header. Direct connectors have none today (no auth-proxy identity layer exists upstream yet).\n- `mcp.session.id` = a stable per-connection ID, present even for anonymous traffic — use it to count distinct *sessions*, not distinct people.\n\nTreat \"distinct users\" as `enduser.id` cardinality for LibreChat traffic, and \"distinct sessions\" (`mcp.session.id`) as the closest available proxy for anonymous direct-connector traffic.",
         "background_color": "gray",
         "font_size": "14",
         "text_align": "left",
@@ -168,7 +168,7 @@
                 "search": { "query": "service:cbioportal-mcp $env" },
                 "group_by": [
                   {
-                    "facet": "@mcp.client",
+                    "facet": "@mcp.client_kind",
                     "limit": 5,
                     "sort": { "order": "desc", "aggregation": "count" }
                   }
@@ -230,7 +230,7 @@
     },
     {
       "definition": {
-        "title": "Requests by Client Name × mcp.client × Tool",
+        "title": "Requests by Client Name × mcp.client_kind × Tool",
         "type": "table",
         "requests": [
           {
@@ -242,7 +242,7 @@
                 "search": { "query": "service:cbioportal-mcp $env" },
                 "group_by": [
                   { "facet": "@mcp.client.name", "limit": 10, "sort": { "order": "desc", "aggregation": "count" } },
-                  { "facet": "@mcp.client", "limit": 5, "sort": { "order": "desc", "aggregation": "count" } },
+                  { "facet": "@mcp.client_kind", "limit": 5, "sort": { "order": "desc", "aggregation": "count" } },
                   { "facet": "@mcp.tool.name", "limit": 15, "sort": { "order": "desc", "aggregation": "count" } }
                 ],
                 "compute": { "aggregation": "count" }

--- a/observability/datadog/monitors.json
+++ b/observability/datadog/monitors.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Datadog monitor definitions built on the mcp.client.name / mcp.client / mcp.tool.success span tags emitted by TelemetryMiddleware (src/cbioportal_mcp/telemetry.py). Apply via the Datadog UI (Monitors > New Monitor > import) or `POST /api/v1/monitor` for each object in `monitors`. Adjust the `env` search fragment and thresholds to your deployment before enabling.",
+  "_comment": "Datadog monitor definitions built on the mcp.client.name / mcp.client_kind / mcp.tool.success span tags emitted by TelemetryMiddleware (src/cbioportal_mcp/telemetry.py). Apply via the Datadog UI (Monitors > New Monitor > import) or `POST /api/v1/monitor` for each object in `monitors`. Adjust the `env` search fragment and thresholds to your deployment before enabling.",
   "monitors": [
     {
       "name": "[cBioPortal MCP] No requests received (heartbeat)",

--- a/src/cbioportal_mcp/telemetry.py
+++ b/src/cbioportal_mcp/telemetry.py
@@ -116,11 +116,11 @@ def _extract_mcp_client_info(
 ) -> tuple[str | None, str | None]:
     """Read the MCP client's self-reported identity from the initialize handshake.
 
-    ``mcp.client`` (see ``_extract_user_identity`` above) only answers "is this
-    LibreChat or not" via the x-user-id header convention. Every non-LibreChat
-    connector — Claude Code, Codex, Claude Desktop, or anything else plugged
-    straight into the MCP endpoint — currently collapses into the same
-    "direct" bucket with no further distinction.
+    ``mcp.client_kind`` (see ``_extract_user_identity`` above) only answers "is
+    this LibreChat or not" via the x-user-id header convention. Every
+    non-LibreChat connector — Claude Code, Codex, Claude Desktop, or anything
+    else plugged straight into the MCP endpoint — currently collapses into the
+    same "direct" bucket with no further distinction.
 
     Every MCP client sends a ``clientInfo`` block (``name``/``version``) as
     part of ``initialize`` regardless of which surface it is, so this is the
@@ -216,7 +216,7 @@ def _llmobs_tool_span(
         span = LLMObs.start_span(span_kind="tool", name=f"mcp.tool.{tool_name}")
         if user_id:
             span.set_tag("usr.id", user_id)
-        span.set_tag("mcp.client", client)
+        span.set_tag("mcp.client_kind", client)
         if client_name:
             span.set_tag("mcp.client.name", client_name)
         if session_id:
@@ -284,12 +284,16 @@ class TelemetryMiddleware(Middleware):
       network.client.ip    Original client IP from X-Forwarded-For (HTTP only)
       mcp.tool.success     True on success, False when an exception propagates
       error.type           Exception class name on failure
-      mcp.client            "librechat" | "direct" | "unknown", from the
+      mcp.client_kind       "librechat" | "direct" | "unknown", from the
                             x-user-id header convention (see _extract_user_identity).
+                            Named to avoid colliding with mcp.client.name/version
+                            below — Datadog treats dotted attribute names as a
+                            hierarchy, so a bare "mcp.client" tag alongside
+                            "mcp.client.name" silently shadows one or the other.
       mcp.client.name       Client app name from the MCP initialize handshake's
                             clientInfo (e.g. "claude-code", "codex") — the
                             signal that distinguishes *which* direct connector
-                            is calling, since mcp.client alone only says
+                            is calling, since mcp.client_kind alone only says
                             "not librechat" for all of them.
       mcp.client.version    Client app version from the same handshake.
       mcp.session.id        MCP transport session ID (HTTP/SSE only) — a stable
@@ -327,7 +331,7 @@ class TelemetryMiddleware(Middleware):
 
         with self._tracer.start_as_current_span(f"mcp.tool/{tool_name}") as span:
             span.set_attribute("mcp.tool.name", tool_name)
-            span.set_attribute("mcp.client", client)
+            span.set_attribute("mcp.client_kind", client)
             if user_id:
                 span.set_attribute("enduser.id", user_id)
             if client_name:

--- a/tests/test_telemetry_e2e.py
+++ b/tests/test_telemetry_e2e.py
@@ -189,8 +189,9 @@ def _run_with_span_capture(call, *, stateless: bool = True):
 
 def test_mcp_client_tag_is_librechat_when_x_user_id_present():
     """
-    The mcp.client OTel span attribute must be 'librechat' when x-user-id is present,
-    regardless of the header value (even empty string counts as LibreChat traffic).
+    The mcp.client_kind OTel span attribute must be 'librechat' when x-user-id is
+    present, regardless of the header value (even empty string counts as LibreChat
+    traffic).
     """
     spans = _run_with_span_capture(
         lambda client: _mcp_call(client, "ping", headers={"x-user-id": "any-value"})
@@ -198,23 +199,23 @@ def test_mcp_client_tag_is_librechat_when_x_user_id_present():
 
     tool_spans = [s for s in spans if s.name == "mcp.tool/ping"]
     assert tool_spans, "Expected an mcp.tool/ping span"
-    assert tool_spans[0].attributes["mcp.client"] == "librechat"
+    assert tool_spans[0].attributes["mcp.client_kind"] == "librechat"
 
 
 def test_mcp_client_tag_is_direct_when_no_x_user_id_header():
-    """The mcp.client OTel span attribute must be 'direct' with no x-user-id header."""
+    """The mcp.client_kind OTel span attribute must be 'direct' with no x-user-id header."""
     spans = _run_with_span_capture(
         lambda client: _mcp_call(client, "ping", headers={})
     )
 
     tool_spans = [s for s in spans if s.name == "mcp.tool/ping"]
     assert tool_spans, "Expected an mcp.tool/ping span"
-    assert tool_spans[0].attributes["mcp.client"] == "direct"
+    assert tool_spans[0].attributes["mcp.client_kind"] == "direct"
 
 
 def test_mcp_client_name_distinguishes_direct_connectors():
     """
-    mcp.client alone only says "not librechat" for every direct connector. The
+    mcp.client_kind alone only says "not librechat" for every direct connector. The
     clientInfo sent during initialize (mcp.client.name/version) is what actually
     distinguishes, e.g., Claude Code from Codex among that "direct" traffic.
     """
@@ -228,7 +229,7 @@ def test_mcp_client_name_distinguishes_direct_connectors():
     tool_spans = [s for s in spans if s.name == "mcp.tool/ping"]
     assert tool_spans, "Expected an mcp.tool/ping span"
     attrs = tool_spans[0].attributes
-    assert attrs["mcp.client"] == "direct"
+    assert attrs["mcp.client_kind"] == "direct"
     assert attrs["mcp.client.name"] == "claude-code"
     assert attrs["mcp.client.version"] == "1.2.3"
 


### PR DESCRIPTION
## Summary

PR #92 added `mcp.client.name`/`mcp.client.version` span attributes (the MCP client's self-reported `clientInfo` from the `initialize` handshake) alongside the pre-existing bare `mcp.client` scalar tag (`"librechat"` / `"direct"` / `"unknown"`, from the `x-user-id` header convention).

Datadog treats dotted OTel attribute names as a hierarchy. A bare `mcp.client` tag living alongside a nested `mcp.client.name` tag under the same prefix causes Datadog to silently drop/shadow the bare scalar on ingestion.

**Confirmed live in production post-merge:**
- Trace search for `@mcp.client:librechat` returns zero results even for spans that should match.
- The attribute-search autocomplete on a post-merge span only suggests `mcp.client.name` — never bare `mcp.client`.

This does **not** reproduce in the local test suite, because the OTel SDK's in-memory span exporter stores attributes as a flat dict with no such collision — so `test_telemetry_e2e.py` passed both before and after #92 despite the bug only manifesting in Datadog's backend.

## Fix

Rename the bare scalar field `mcp.client` → `mcp.client_kind` everywhere it's set (`_llmobs_tool_span`, `TelemetryMiddleware.on_call_tool`) and referenced (docstrings, tests, dashboard/monitor JSON, README). `mcp.client.name`/`mcp.client.version` are untouched — this only resolves the naming collision, no behavior or value changes.

## Test plan

- [x] `uv run python -m pytest -q` — 36 passed
- [x] `uv run ruff check` on changed files — no new issues introduced (pre-existing lint debt on unrelated lines, unchanged by this diff)
- [x] Verified via grep no remaining bare `mcp.client` references outside historical/explanatory comments
- [ ] Confirm post-deploy that `@mcp.client_kind:librechat` search and dashboard/monitor queries resolve correctly in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)