### PR TITLE
Canonical recipe for 'studies by available data types' (fixes #102)

### DIFF
--- a/src/cbioportal_mcp/resources/sample-filtering-guide.md
+++ b/src/cbioportal_mcp/resources/sample-filtering-guide.md
@@ -48,6 +48,54 @@ WHERE
 GROUP BY cs.cancer_study_identifier, cs.name, cs.description;
 ```
 
+### 4. Find Studies by Available Data Types
+
+Use this when the user asks *"which studies have mutation and copy-number data for X"*, *"studies with expression for Y"*, or any *"studies with Z data"* question. One JOIN against `genetic_profile` answers it — no schema exploration needed.
+
+**Canonical query — studies with ALL requested data types for a cancer type:**
+
+```sql
+SELECT
+    cs.cancer_study_identifier,
+    cs.name,
+    cs.type_of_cancer_id,
+    COUNT(DISTINCT gp.genetic_alteration_type) as matched_profile_count
+FROM cancer_study cs
+JOIN genetic_profile gp ON cs.cancer_study_id = gp.cancer_study_id
+WHERE cs.type_of_cancer_id = 'luad'          -- ← OncoTree code from search_oncotree
+  AND gp.genetic_alteration_type IN (
+      'MUTATION_EXTENDED',                    -- ← required data types
+      'COPY_NUMBER_ALTERATION'
+  )
+GROUP BY cs.cancer_study_identifier, cs.name, cs.type_of_cancer_id
+HAVING matched_profile_count = 2              -- ← must equal the count of requested types
+ORDER BY cs.cancer_study_identifier;
+```
+
+**`genetic_alteration_type` values you'll reference:**
+
+| Data type in the user's question | `genetic_alteration_type` |
+|---|---|
+| mutation / mutations | `MUTATION_EXTENDED` |
+| copy-number / CNA / amplification / deletion | `COPY_NUMBER_ALTERATION` |
+| mRNA expression | `MRNA_EXPRESSION` |
+| protein expression / RPPA | `PROTEIN_LEVEL` |
+| methylation | `METHYLATION` |
+| structural variant / fusion | `STRUCTURAL_VARIANT` |
+
+**Rules:**
+
+- **Resolve the cancer type first** via `search_oncotree(term)`; use the returned `type_of_cancer_id` (lowercase) in the WHERE clause. Don't `ILIKE '%lung%'`.
+- **`HAVING = N`** enforces "study has ALL N requested types". Use `HAVING >= 1` for "study has AT LEAST ONE of the types".
+- Do NOT `clickhouse_list_tables` or `clickhouse_list_table_columns` first — this query is the schema you need.
+- Do NOT run per-study probing queries. One query returns the whole list.
+
+**Worked example — "Which cBioPortal studies include lung adenocarcinoma samples with mutation and copy-number data?"**
+
+1. `search_oncotree("lung adenocarcinoma")` → `LUAD`
+2. Run the canonical query above with `type_of_cancer_id = 'luad'` and the two `genetic_alteration_type` values
+3. Return the list of studies, with `list_studies(search="<id>")` (or the navigator) only if the user then wants details on a specific one
+
 ## Sample Type Filtering
 
 ### 1. Common Sample Types

--- a/src/cbioportal_mcp/resources/system-prompt.md
+++ b/src/cbioportal_mcp/resources/system-prompt.md
@@ -13,6 +13,7 @@ BEFORE ANSWERING ANY QUESTION, you MUST:
    - **Group comparison, p-value, mutual exclusivity, co-occurrence, hazard ratio, median survival, "aggressive"/"better outcome" questions**: read `cbioportal://statistical-tests-guide`. Pay attention to the **HARD RULES** at the top — ClickHouse cannot run tests, and you must never invent a p-value, fabricate a "median" from `AVG()`, or report median OS without Kaplan-Meier. Use the Approved Response Templates to hand off to cBioPortal Group Comparison / R / Python.
    - Clinical data questions: read `cbioportal://clinical-data-guide`
    - Sample/study filtering: read `cbioportal://sample-filtering-guide`
+     - **"Which studies have X and Y data types"** ("studies with mutation and CNA", "studies with expression for gene Z"): jump to the "Find Studies by Available Data Types" section of that guide. There is one canonical `JOIN genetic_profile` query — do NOT explore the schema first.
    - Missing, external, or substitute study/cohort questions (PBTA, pediatric cBioPortal, GENIE, private portals): read `cbioportal://study-resolution-guide`
    - Treatment questions: read `cbioportal://treatment-guide`
    - **Gene expression / copy-number / methylation / correlation between two genes**: read `cbioportal://gene-expression-guide`. This is the home for `genetic_alteration_derived` and the `gene_pair_coexpression` view. Don't try to answer expression-correlation questions through mutation-frequency tools.


### PR DESCRIPTION
Closes #102.

## Summary

The example prompt on the cBioChat landing page — *\"Which cBioPortal studies include lung adenocarcinoma samples with mutation and copy-number data?\"* — currently takes 9 tool-call rounds. Langfuse shows the sequence is:

\`list_guides\` → \`search_oncotree\` → \`read_guide\` → **\`clickhouse_list_tables\`** → **\`clickhouse_list_table_columns\` × 2** → \`clickhouse_run_select_query\` × 2 → navigator calls.

The 3 schema-exploration rounds happen because no guide has the recipe for filtering studies by \`genetic_profile.genetic_alteration_type\`, so the agent probes the schema before writing SQL. The prompt-only fix in #97 didn't cover this class because it's a *filtered* query, not an enumeration.

## Changes

1. **\`sample-filtering-guide.md\`** — new section \"4. Find Studies by Available Data Types\" with:
    - Canonical \`JOIN genetic_profile\` + \`HAVING count = N\` recipe
    - Value table for \`genetic_alteration_type\` (MUTATION_EXTENDED / COPY_NUMBER_ALTERATION / MRNA_EXPRESSION / PROTEIN_LEVEL / METHYLATION / STRUCTURAL_VARIANT)
    - Worked example using the exact landing-page prompt
    - \"do NOT explore the schema first\" rule
2. **\`system-prompt.md\`** — sub-bullet under sample/study filtering that routes *\"which studies have X and Y data\"* questions directly to the new section.

## Expected impact

Question should collapse from 9 rounds to ~3: \`search_oncotree\` → one canonical SELECT → optional navigator link. Same-shape prompt: fewer round-trips, faster.

## Test plan

- [ ] Merge, wait for image to roll (or manually restart clickhouse-mcp on 203 + 666)
- [ ] Ask the landing-page prompt again — expect ≤4 tool rounds instead of 9
- [ ] Ask a related question (\"which studies have expression data for BRCA1\") — should follow the same pattern
- [ ] Existing questions not matching this pattern should continue to work unchanged