### PR TITLE
Fix stale system prompt README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > **WARNING ⚠️: This is still under construction**
 
-A wrapper around the [mcp-clickhouse server](https://github.com/ClickHouse/mcp-clickhouse) adding a [cBioPortal-specific system prompt](https://github.com/cBioPortal/cbioportal-mcp/blob/main/src/cbioportal_mcp/prompts/cbioportal_prompt.py).
+A wrapper around the [mcp-clickhouse server](https://github.com/ClickHouse/mcp-clickhouse) adding a [cBioPortal-specific system prompt](https://github.com/cBioPortal/cbioportal-mcp/blob/main/src/cbioportal_mcp/resources/system-prompt.md).
 
 ## Installation
 

--- a/tests/test_readme_links.py
+++ b/tests/test_readme_links.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+
+
+def test_readme_links_current_system_prompt_file():
+    readme = Path("README.md").read_text(encoding="utf-8")
+
+    assert "src/cbioportal_mcp/resources/system-prompt.md" in readme
+    assert "src/cbioportal_mcp/prompts/cbioportal_prompt.py" not in readme


### PR DESCRIPTION
## Summary
- Point the README at the packaged system prompt markdown file instead of the removed cbioportal_prompt.py path.
- Add a regression test for the README link.

Fixes #16.

## Testing
- uv run pytest tests/test_readme_links.py -q