### PR TITLE
Default user-facing code samples to the REST API

### DIFF
--- a/src/cbioportal_mcp/resources/faq-guide.md
+++ b/src/cbioportal_mcp/resources/faq-guide.md
@@ -156,6 +156,8 @@ cBioPortal imports some GDC data and presents it in a user-friendly interface fo
 
 cBioPortal provides a REST API (Swagger-documented), as well as R and MATLAB interfaces for programmatic access. The public API is available at https://www.cbioportal.org/api.
 
+When writing code for regular cBioPortal users, default to the REST API. Do not provide ClickHouse connection code, backend credentials, or direct SQL driver setup unless the user explicitly says they have backend database access. If a workflow is not available through the REST API, explain the limitation and point to cBioPortal UI/download options or DataHub rather than assuming the user can query ClickHouse.
+
 ## Combined and Virtual Studies
 
 - **Virtual Study**: A custom study comprised of samples from one or more existing studies, with permanent shareable links.

--- a/src/cbioportal_mcp/resources/system-prompt.md
+++ b/src/cbioportal_mcp/resources/system-prompt.md
@@ -46,6 +46,14 @@ Use the guides for full details; this is a quick reminder:
 - `clinical_event_derived` columns: `key`, `value` (NOT `attr_id`/`attr_value`)
 - Treatment data is in `clinical_event_derived`, NOT `clinical_data_derived`
 
+## User-Facing Code Samples
+
+When the user asks for code they can run, default to public cBioPortal interfaces:
+
+- Use the cBioPortal REST API (`https://www.cbioportal.org/api`) for regular users.
+- Do not write ClickHouse-driver code, backend credentials, or direct SQL connection snippets unless the user explicitly says they administer the MCP/ClickHouse backend.
+- If the REST API cannot express the requested query, say that clearly and offer the closest REST API workflow or a cBioPortal/DataHub download path. Treat direct ClickHouse access as an internal deployment path, not the default user workflow.
+
 ## Statistical Analysis
 Before performing any group comparison or statistical test:
 1. ALWAYS read the statistical-tests-guide first: call `read_guide("cbioportal://statistical-tests-guide")` — pay particular attention to the **HARD RULES — NEVER FABRICATE A STATISTIC** section at the top

--- a/tests/test_source_boundary_guidance.py
+++ b/tests/test_source_boundary_guidance.py
@@ -23,3 +23,17 @@ def test_system_prompt_labels_general_knowledge_even_after_tool_calls():
     assert "explicitly state which portion is not from cBioPortal data" in prompt
     assert "The label depends on the source of the claim" in prompt
     assert "not merely whether a tool was called" in prompt
+
+
+def test_user_facing_code_samples_default_to_public_rest_api():
+    prompt = server._load_resource("system-prompt.md")
+    faq = server._faq_guide_text()
+
+    assert "## User-Facing Code Samples" in prompt
+    assert "default to public cBioPortal interfaces" in prompt
+    assert "https://www.cbioportal.org/api" in prompt
+    assert "Do not write ClickHouse-driver code" in prompt
+    assert "unless the user explicitly says they administer" in prompt
+
+    assert "default to the REST API" in faq
+    assert "Do not provide ClickHouse connection code" in faq


### PR DESCRIPTION
## Summary
- Add a system-prompt rule that user-runnable code should default to the public cBioPortal REST API.
- Extend the FAQ API section to warn against ClickHouse connection examples for regular users.
- Add regression coverage for the new guidance.

Fixes #95.

## Testing
- uv run pytest tests/test_source_boundary_guidance.py -q