### PR TITLE
Harden literature scope boundary for rare variant answers

### DIFF
--- a/src/cbioportal_mcp/resources/common-pitfalls.md
+++ b/src/cbioportal_mcp/resources/common-pitfalls.md
@@ -552,6 +552,27 @@ Use this pattern when:
 
 Do not query unrelated genes or "helpful" substitutes unless you state why and the user accepts the substitution.
 
+### 17b. 🚨 IMPLIED LITERATURE REVIEW FOR RARE VARIANTS
+
+Do not present a rare-variant answer as though you reviewed papers or clinical guidelines when the only available evidence came from cBioPortal.
+
+#### ❌ Wrong: imply external literature support
+
+> User: *"I received a report with PIK3CA p.*1069Wext*3. Can you provide details?"*
+> Agent: *"The literature indicates that C-terminal extension mutations are poorly characterized..."*
+
+#### ✅ Correct: keep the source boundary visible
+
+> I can check cBioPortal for occurrences of `PIK3CA p.*1069Wext*3` and any mutation annotations exposed in this deployment. cBioPortal occurrence data does not establish biological significance by itself. For functional or clinical interpretation, you would need an external curated source such as OncoKB, ClinVar, UniProt, or the primary literature.
+
+Correct workflow:
+
+1. Query the literal variant, gene, and study/cancer scope the user asked for.
+2. Report counts and study/cancer contexts with denominators when available.
+3. Check only annotation fields that actually exist in the schema; do not invent OncoKB or driver status.
+4. If no external-source tool was used, do not say "in the literature" or "studies have shown."
+5. End with a clear handoff for biological significance or clinical interpretation.
+
 ### 18. 🚨 OUT-OF-SCOPE DRIFT AFTER USER PUSHBACK
 
 If you decline a request because it is outside cBioPortal scope, hold that boundary when the user rephrases or pushes gently.
@@ -615,8 +636,9 @@ Example:
 17. **Never fabricate OncoKB/driver annotations** — check for driver columns first
 18. **Never silently rewrite the user's query** — if "point mutation" or "V600V" is ambiguous or unusual, surface the normalization or ask, don't substitute. See pitfall #16.
 19. **Validate flawed premises early** — if the gene, alteration, study, or data field is absent, say so before running adjacent analyses.
-20. **Hold scope boundaries after refusal** — do not provide paper critiques, slide outlines, external pipeline code, or medical advice after user pushback.
-21. **Do not promise unavailable outputs** — provide data/handoffs instead of claiming to create plots, CSV files, or external apps.
+20. **Do not imply literature review** — rare-variant significance requires explicit external evidence; cBioPortal occurrence counts alone are not literature or clinical interpretation.
+21. **Hold scope boundaries after refusal** — do not provide paper critiques, slide outlines, external pipeline code, or medical advice after user pushback.
+22. **Do not promise unavailable outputs** — provide data/handoffs instead of claiming to create plots, CSV files, or external apps.
 
 ### 21. 🚨 ENUMERATION / CATALOG QUESTIONS TRIGGER SCHEMA EXPLORATION
 
@@ -671,6 +693,7 @@ Before trusting your results, ask:
 - [ ] Did I verify all tables and columns exist before querying them?
 - [ ] Did I answer the literal question, or did I silently rewrite it? If I normalized a term ("point mutation" → SNV set, "V600V" → V600E), did I surface that to the user?
 - [ ] Did I validate the user's premise before querying adjacent data?
+- [ ] Did I avoid claiming literature, guideline, or external-database support unless a tool or user-provided source supplied it?
 - [ ] Did I keep scope boundaries after any refusal?
 - [ ] Did I avoid promising plots, downloads, or external-code debugging that this MCP server cannot perform?
 - [ ] For enumeration/catalog questions ("what cancer types", "what studies", "what guides"), did I use a first-class list tool once instead of exploring the schema?

--- a/src/cbioportal_mcp/resources/system-prompt.md
+++ b/src/cbioportal_mcp/resources/system-prompt.md
@@ -74,11 +74,13 @@ Keep a visible boundary between answers grounded in cBioPortal and answers from 
 
 - **cBioPortal-grounded content** means database query results, study metadata, cBioPortal resource guides, or cBioPortal FAQ content.
 - **General-knowledge content** means biology, mechanism, clinical interpretation, literature-style background, or textbook-like explanation that was not obtained from cBioPortal database rows or cBioPortal guides.
+- Never claim or imply that you reviewed literature, clinical guidelines, external databases, or papers unless the user provided that source content in the conversation or a tool explicitly retrieved it. Avoid phrases such as "the literature shows", "studies have shown", or "after reviewing the literature" when the only evidence came from cBioPortal.
 - If the user's question is a pure biology/mechanism question that cBioPortal cannot directly answer from its data (for example, "what do IDH1 mutations do?"), do not immediately give an uncaveated textbook answer. Softly redirect first:
   "This is a general biology question, not something cBioPortal data directly answers. I can either answer from general biomedical knowledge with that caveat, or look up cBioPortal-specific data about [gene/alteration] such as frequencies, cancer types, co-mutations, clinical attributes, or treatments."
 - If you do provide any general-knowledge answer or paragraph, state in natural prose near that content that it is general biomedical knowledge and not from cBioPortal data. Do not use a bracketed pre-hook or tag.
 - If a response mixes cBioPortal data and general knowledge, keep cBioPortal-derived findings and general-knowledge interpretation in separate paragraphs or sections, and explicitly state which portion is not from cBioPortal data.
 - Do not use guide reads, schema checks, or other tool calls as a substitute for this source label. The label depends on the source of the claim, not merely whether a tool was called.
+- For rare-variant questions, answer in this order: cBioPortal occurrence/absence, any queried database annotation that actually exists, then a clear boundary that biological significance requires external sources such as OncoKB, UniProt, ClinVar, or primary literature.
 
 ## Out of Scope — Do NOT Answer
 

--- a/tests/test_source_boundary_guidance.py
+++ b/tests/test_source_boundary_guidance.py
@@ -23,3 +23,18 @@ def test_system_prompt_labels_general_knowledge_even_after_tool_calls():
     assert "explicitly state which portion is not from cBioPortal data" in prompt
     assert "The label depends on the source of the claim" in prompt
     assert "not merely whether a tool was called" in prompt
+
+
+def test_system_prompt_forbids_implied_literature_review():
+    prompt = server._load_resource("system-prompt.md")
+    pitfalls = server._common_pitfalls_guide_text()
+
+    assert "Never claim or imply that you reviewed literature" in prompt
+    assert "Avoid phrases such as" in prompt
+    assert "the literature shows" in prompt
+    assert "For rare-variant questions" in prompt
+    assert "cBioPortal occurrence/absence" in prompt
+
+    assert "IMPLIED LITERATURE REVIEW FOR RARE VARIANTS" in pitfalls
+    assert "PIK3CA p.*1069Wext*3" in pitfalls
+    assert "cBioPortal occurrence data does not establish biological significance" in pitfalls


### PR DESCRIPTION
## Summary
- Add explicit system-prompt language forbidding implied literature or guideline review when only cBioPortal evidence was queried.
- Add a rare-variant pitfall/template using the PIK3CA C-terminal extension case from the issue.
- Add regression coverage for the prompt and guide language.

Fixes #99.

## Testing
- uv run pytest tests/test_source_boundary_guidance.py -q