### PR TITLE
Keep ACC answers scoped to site-specific OncoTree matches

### DIFF
--- a/src/cbioportal_mcp/resources/common-pitfalls.md
+++ b/src/cbioportal_mcp/resources/common-pitfalls.md
@@ -552,6 +552,30 @@ Use this pattern when:
 
 Do not query unrelated genes or "helpful" substitutes unless you state why and the user accepts the substitution.
 
+### 17b. 🚨 AMBIGUOUS ACC / ADENOID CYSTIC CARCINOMA SCOPES
+
+`ACC` is ambiguous. It can mean adrenocortical carcinoma (`ACC`), adenoid cystic carcinoma of the salivary gland (`ACYC`), adenoid cystic breast cancer (`ACBC`), or other site-specific entities. When the user names an anatomical site, lock every downstream query and narrative summary to the matching OncoTree code.
+
+Common examples:
+
+| User wording | Use this scope |
+|---|---|
+| "salivary cancer (adenoid cystic carcinoma)" | `ACYC` — Adenoid Cystic Carcinoma, Salivary Gland Cancer |
+| "adenoid cystic breast cancer" | `ACBC` |
+| "adrenocortical carcinoma" or exact code `ACC` | `ACC` |
+
+#### ❌ Wrong: split scopes inside one answer
+
+> The OncoPrint link is filtered to salivary ACC, but the driver summary aggregates all ACC-labeled cancer types.
+
+#### ✅ Correct: keep one scope
+
+After resolving the site-specific OncoTree code, quote it back to the user and use it for every query in that turn:
+
+> I am treating this as salivary gland adenoid cystic carcinoma (`ACYC`), not every cancer abbreviated ACC.
+
+If any result row or narrative claim comes from another `cancer_type_detailed`, drop it or explicitly label it as outside the requested scope.
+
 ### 18. 🚨 OUT-OF-SCOPE DRIFT AFTER USER PUSHBACK
 
 If you decline a request because it is outside cBioPortal scope, hold that boundary when the user rephrases or pushes gently.
@@ -615,8 +639,9 @@ Example:
 17. **Never fabricate OncoKB/driver annotations** — check for driver columns first
 18. **Never silently rewrite the user's query** — if "point mutation" or "V600V" is ambiguous or unusual, surface the normalization or ask, don't substitute. See pitfall #16.
 19. **Validate flawed premises early** — if the gene, alteration, study, or data field is absent, say so before running adjacent analyses.
-20. **Hold scope boundaries after refusal** — do not provide paper critiques, slide outlines, external pipeline code, or medical advice after user pushback.
-21. **Do not promise unavailable outputs** — provide data/handoffs instead of claiming to create plots, CSV files, or external apps.
+20. **Lock site-specific cancer scopes** — if the user specifies salivary ACC, use `ACYC` throughout and do not mix in breast/lung/adrenal ACC rows.
+21. **Hold scope boundaries after refusal** — do not provide paper critiques, slide outlines, external pipeline code, or medical advice after user pushback.
+22. **Do not promise unavailable outputs** — provide data/handoffs instead of claiming to create plots, CSV files, or external apps.
 
 ### 21. 🚨 ENUMERATION / CATALOG QUESTIONS TRIGGER SCHEMA EXPLORATION
 
@@ -671,6 +696,7 @@ Before trusting your results, ask:
 - [ ] Did I verify all tables and columns exist before querying them?
 - [ ] Did I answer the literal question, or did I silently rewrite it? If I normalized a term ("point mutation" → SNV set, "V600V" → V600E), did I surface that to the user?
 - [ ] Did I validate the user's premise before querying adjacent data?
+- [ ] If the user named an anatomical site with an ambiguous abbreviation like ACC, did every query use the same site-specific OncoTree scope?
 - [ ] Did I keep scope boundaries after any refusal?
 - [ ] Did I avoid promising plots, downloads, or external-code debugging that this MCP server cannot perform?
 - [ ] For enumeration/catalog questions ("what cancer types", "what studies", "what guides"), did I use a first-class list tool once instead of exploring the schema?

--- a/src/cbioportal_mcp/server.py
+++ b/src/cbioportal_mcp/server.py
@@ -1009,6 +1009,7 @@ def search_oncotree(search_term: str) -> list[dict]:
     term_lower = search_term.strip().lower()
     if not term_lower:
         return [{"error": "search_term cannot be empty"}]
+    term_tokens = re.findall(r"[a-z0-9]+", term_lower)
 
     entries_by_code = {e["code"]: e for e in entries if "code" in e}
 
@@ -1022,6 +1023,7 @@ def search_oncotree(search_term: str) -> list[dict]:
         main_type_lower = main_type.lower()
         tissue = entry.get("tissue", "")
         tissue_lower = tissue.lower()
+        combined_text = f"{code_lower} {name_lower} {main_type_lower} {tissue_lower}"
         revocations = [r.lower() for r in entry.get("revocations", [])]
         precursors = [p.lower() for p in entry.get("precursors", [])]
 
@@ -1053,6 +1055,10 @@ def search_oncotree(search_term: str) -> list[dict]:
         # Tissue match
         elif term_lower in tissue_lower:
             score = 40
+        # Multi-word clinical phrasing often combines histology and site, e.g.
+        # "salivary adenoid cystic carcinoma" spans name + mainType.
+        elif term_tokens and all(token in combined_text for token in term_tokens):
+            score = 55
 
         if score > 0:
             result = {

--- a/tests/test_guide_layer_issue_coverage.py
+++ b/tests/test_guide_layer_issue_coverage.py
@@ -60,3 +60,19 @@ def test_existing_guides_cover_open_issue_patterns():
     assert "FLAWED PREMISE OR NONEXISTENT DATA FIELD" in pitfalls
     assert "OUT-OF-SCOPE DRIFT AFTER USER PUSHBACK" in pitfalls
     assert "MISLEADING OUTPUT PROMISES" in pitfalls
+
+
+def test_common_pitfalls_cover_ambiguous_acc_scope():
+    pitfalls = server._common_pitfalls_guide_text()
+
+    assert "AMBIGUOUS ACC / ADENOID CYSTIC CARCINOMA SCOPES" in pitfalls
+    assert "salivary gland adenoid cystic carcinoma (`ACYC`)" in pitfalls
+    assert "not every cancer abbreviated ACC" in pitfalls
+    assert "do not mix in breast/lung/adrenal ACC rows" in pitfalls
+
+
+def test_search_oncotree_matches_site_plus_histology_terms():
+    results = server.search_oncotree.fn("salivary adenoid cystic carcinoma")
+
+    assert results[0]["code"] == "ACYC"
+    assert results[0]["mainType"] == "Salivary Gland Cancer"


### PR DESCRIPTION
## Summary
- Add a common-pitfalls entry for ambiguous ACC/adenoid cystic carcinoma scope drift.
- Teach search_oncotree to match multi-word clinical phrases that span histology plus site/mainType, such as salivary adenoid cystic carcinoma.
- Add regression coverage for both the guide text and ACYC lookup behavior.

Fixes #94.

## Testing
- uv run pytest tests/test_guide_layer_issue_coverage.py -q