### PR TITLE
Calibrate response depth for technical cBioPortal queries

### DIFF
--- a/src/cbioportal_mcp/resources/system-prompt.md
+++ b/src/cbioportal_mcp/resources/system-prompt.md
@@ -68,6 +68,18 @@ cBioPortal is a cancer genomics research database with data from published studi
 - Gene alterations (mutations, copy number changes, structural variants)
 - Comparisons between cancer types or patient cohorts within the database
 
+## Response Depth Calibration
+
+Default to concise answers, but use researcher-grade detail when the user's wording signals a technical cancer-genomics analysis. Signals include specific gene symbols, variants, mutation classes, named cohorts/studies, cancer subtypes, treatment/outcome variables, or requests such as "compare", "frequency", "distribution", "drivers", "co-mutations", or "expression".
+
+For researcher-grade answers:
+
+- Include raw counts and denominators inline, not only percentages.
+- Add the selected cohort/study and counting unit.
+- Include one useful breakdown when supported by the query, such as cancer type, mutation type, profile coverage, or clinical group.
+- Avoid pop-science summaries that replace the requested data with broad biological explanation.
+- End with concrete follow-up options tied to the result, not a generic "anything else?"
+
 ## Source Boundaries — cBioPortal Data vs General Knowledge
 
 Keep a visible boundary between answers grounded in cBioPortal and answers from general biomedical knowledge.

--- a/tests/test_source_boundary_guidance.py
+++ b/tests/test_source_boundary_guidance.py
@@ -23,3 +23,14 @@ def test_system_prompt_labels_general_knowledge_even_after_tool_calls():
     assert "explicitly state which portion is not from cBioPortal data" in prompt
     assert "The label depends on the source of the claim" in prompt
     assert "not merely whether a tool was called" in prompt
+
+
+def test_system_prompt_calibrates_response_depth_for_researcher_queries():
+    prompt = server._load_resource("system-prompt.md")
+
+    assert "## Response Depth Calibration" in prompt
+    assert "researcher-grade detail" in prompt
+    assert "specific gene symbols" in prompt
+    assert "raw counts and denominators" in prompt
+    assert "selected cohort/study and counting unit" in prompt
+    assert "Avoid pop-science summaries" in prompt


### PR DESCRIPTION
## Summary
- Add system-prompt guidance for researcher-grade answers when users ask technical gene/cohort/variant questions.
- Require counts, denominators, cohort/counting-unit context, and useful breakdowns when supported.
- Add regression coverage for the new prompt section.

Fixes #43.

## Testing
- uv run pytest tests/test_source_boundary_guidance.py -q