### PR TITLE
Include cBioPortal study URLs in study lists

### DIFF
--- a/src/cbioportal_mcp/resources/faq-guide.md
+++ b/src/cbioportal_mcp/resources/faq-guide.md
@@ -132,7 +132,7 @@ When searching for studies on a specific topic, use `list_studies(search=...)` w
 
 ### Study Links
 
-- **View a study:** `https://www.cbioportal.org/study?id={study_id}` (e.g., `https://www.cbioportal.org/study?id=msk_ch_2020`)
+- **View a study:** `https://www.cbioportal.org/study/summary?id={study_id}` (e.g., `https://www.cbioportal.org/study/summary?id=msk_ch_2020`)
 - **Download study data:** `https://datahub.assets.cbioportal.org/{study_id}.tar.gz`
 
 ## Copy Number (GISTIC) Thresholds

--- a/src/cbioportal_mcp/resources/system-prompt.md
+++ b/src/cbioportal_mcp/resources/system-prompt.md
@@ -34,6 +34,7 @@ BEFORE ANSWERING ANY QUESTION, you MUST:
 - **Never use `LIKE '%abbreviation%'`** for cancer type matching — always resolve through OncoTree first
 - If `search_oncotree` returns multiple plausible matches, ask the user which cancer type they mean before querying
 - Use `list_studies(search)` for study discovery after resolving the cancer type
+- When an answer lists studies, include the cBioPortal study URL from `list_studies()` or render each study as `[Study Name](https://www.cbioportal.org/study/summary?id=<study_id>)`.
 - Also read `cbioportal://clinical-data-guide` for clinical data query patterns
 - Do NOT hardcode study filters unless the question explicitly names a study
 - Questions may span multiple studies or all of cBioPortal

--- a/src/cbioportal_mcp/server.py
+++ b/src/cbioportal_mcp/server.py
@@ -910,6 +910,11 @@ WHERE cancer_study_identifier = '{study_id}'
 
 # Maximum allowed limit for list queries to prevent expensive unbounded queries
 MAX_LIST_LIMIT = 100
+CBIOPORTAL_STUDY_SUMMARY_URL_TEMPLATE = "https://www.cbioportal.org/study/summary?id={study_id}"
+
+
+def _study_summary_url(study_id: str) -> str:
+    return CBIOPORTAL_STUDY_SUMMARY_URL_TEMPLATE.format(study_id=study_id)
 
 @mcp.tool()
 def list_studies(search: str = None, limit: int = 20) -> list[dict]:
@@ -922,7 +927,8 @@ def list_studies(search: str = None, limit: int = 20) -> list[dict]:
         limit: Maximum number of studies to return (default 20, max 100)
 
     Returns:
-        List of studies with their identifiers, names, descriptions, sample counts, and guide availability
+        List of studies with identifiers, names, descriptions, sample counts, cBioPortal URLs,
+        and guide availability
     """
     available_guides = set(_list_available_study_guides())
     
@@ -971,6 +977,8 @@ def list_studies(search: str = None, limit: int = 20) -> list[dict]:
         for study in results:
             study_id = study.get('cancer_study_identifier', '')
             study['has_guide'] = study_id in available_guides
+            if study_id:
+                study['url'] = _study_summary_url(study_id)
         
         return results
         

--- a/tests/test_list_studies.py
+++ b/tests/test_list_studies.py
@@ -1,0 +1,41 @@
+from cbioportal_mcp import server
+
+
+def test_list_studies_adds_clickable_study_urls(monkeypatch):
+    monkeypatch.setattr(server, "_list_available_study_guides", lambda: ["brca_test_2026"])
+    monkeypatch.setattr(
+        server,
+        "run_select_query",
+        lambda query: [
+            {
+                "cancer_study_identifier": "brca_test_2026",
+                "name": "Breast Test Study",
+                "description": "Test study",
+                "type_of_cancer_id": "brca",
+                "sample_count": 42,
+            }
+        ],
+    )
+
+    studies = server.list_studies.fn(search="breast", limit=20)
+
+    assert studies == [
+        {
+            "cancer_study_identifier": "brca_test_2026",
+            "name": "Breast Test Study",
+            "description": "Test study",
+            "type_of_cancer_id": "brca",
+            "sample_count": 42,
+            "has_guide": True,
+            "url": "https://www.cbioportal.org/study/summary?id=brca_test_2026",
+        }
+    ]
+
+
+def test_prompt_and_faq_reference_study_summary_links():
+    prompt = server._load_resource("system-prompt.md")
+    faq = server._faq_guide_text()
+
+    assert "When an answer lists studies" in prompt
+    assert "https://www.cbioportal.org/study/summary?id=<study_id>" in prompt
+    assert "https://www.cbioportal.org/study/summary?id={study_id}" in faq


### PR DESCRIPTION
## Summary
- Add a cBioPortal study summary URL to each list_studies row.
- Update the system prompt and FAQ to use the study summary URL template when listing studies.
- Add tests for tool output and prompt/FAQ link guidance.

Fixes #96.

## Testing
- uv run pytest tests/test_list_studies.py -q