### PR TITLE
Speed up default list_studies discovery

### DIFF
--- a/src/cbioportal_mcp/server.py
+++ b/src/cbioportal_mcp/server.py
@@ -239,17 +239,17 @@ def main():
         logger.critical("❌ ClickHouse permission check failed: %s", e)
         sys.exit(2)
 
-    # Warm the list_studies cache in the background so most early callers get
-    # a warm cache without blocking server startup on the ClickHouse round
-    # trip. Best-effort and fire-and-forget: a failure here just means the
-    # cache warms lazily on first real use instead, same as before this ran.
-    def _warm_studies_cache():
-        try:
-            _all_studies_query()
-        except Exception as e:
-            logger.warning(f"Failed to pre-warm list_studies cache: {e}")
+    # Warm the list_studies cache immediately, without blocking server
+    # startup on the ClickHouse round trip, then keep it proactively
+    # refreshed on the same background thread for the life of the process
+    # (see STUDIES_CACHE_REFRESH_INTERVAL_SECONDS) -- so it's not just the
+    # first caller after startup that benefits, but every caller, since a
+    # live request should almost never be the one paying for the refetch.
+    def _warm_then_keep_studies_cache_fresh():
+        _refresh_studies_cache_once()
+        _refresh_studies_cache_forever()
 
-    threading.Thread(target=_warm_studies_cache, daemon=True).start()
+    threading.Thread(target=_warm_then_keep_studies_cache_fresh, daemon=True).start()
 
     # Set up OpenTelemetry → Datadog agent (no-op if env vars not set or agent unreachable)
     provider = configure_telemetry()
@@ -908,10 +908,19 @@ WHERE cancer_study_identifier = '{study_id}'
 MAX_LIST_LIMIT = 100
 
 
-# How long a cached study snapshot is served before the next call refetches it.
-# The underlying data only changes via the daily clone job, so this just bounds
-# how long a study add/remove can take to become visible without a restart.
+# How long a cached study snapshot is served before an on-demand call
+# refetches it. The underlying data only changes via the daily clone job, so
+# this is a fallback staleness bound, not the primary refresh mechanism: see
+# STUDIES_CACHE_REFRESH_INTERVAL_SECONDS below for that.
 STUDIES_CACHE_TTL_SECONDS = 900
+
+# How often the background loop started in main() proactively refetches,
+# well ahead of STUDIES_CACHE_TTL_SECONDS expiry, so a live list_studies()
+# call almost never lands on the request that pays for the ClickHouse round
+# trip -- only the periodic background refresh does. Kept with headroom
+# below the TTL so a slow or delayed refresh cycle doesn't still let the
+# cache go stale before the next one lands.
+STUDIES_CACHE_REFRESH_INTERVAL_SECONDS = 600
 
 _studies_cache_lock = threading.Lock()
 _studies_cache_rows: tuple[tuple[tuple[str, object], ...], ...] | None = None
@@ -926,25 +935,52 @@ def _clear_studies_cache() -> None:
         _studies_cache_fetched_at = 0.0
 
 
-def _all_studies_query() -> tuple[tuple[tuple[str, object], ...], ...]:
-    """Return every study's full detail, refetched at most every
-    STUDIES_CACHE_TTL_SECONDS.
-
-    Mirrors cbioportal's own /api/studies?projection=DETAILED, which caches
-    the entire study list rather than one entry per distinct query shape.
-    list_studies() filters this single snapshot in Python by search/limit/
-    verbose, so every call is a cache hit regardless of the search term used,
-    except for the one caller per TTL window that pays the refetch.
+def _fetch_and_store_studies() -> tuple[tuple[tuple[str, object], ...], ...]:
+    """Query ClickHouse for every study's full detail and store it as the
+    cache snapshot. Caller must hold _studies_cache_lock.
 
     Use sample/patient for counts instead of clinical_data_derived. The latter
     has many clinical-attribute rows per sample and makes first-connect study
     discovery slower than it needs to be.
+    """
+    global _studies_cache_rows, _studies_cache_fetched_at
+    query = """
+                SELECT
+                    cs.cancer_study_identifier,
+                    cs.name,
+                    cs.description,
+                    cs.type_of_cancer_id,
+                    COUNT(DISTINCT s.internal_id) as sample_count
+                FROM cancer_study cs
+                LEFT JOIN patient p ON p.cancer_study_id = cs.cancer_study_id
+                LEFT JOIN sample s ON s.patient_id = p.internal_id
+                GROUP BY cs.cancer_study_identifier, cs.name, cs.description, cs.type_of_cancer_id
+                ORDER BY sample_count DESC
+            """
+    rows = run_select_query(query)
+    _studies_cache_rows = tuple(tuple(row.items()) for row in rows)
+    _studies_cache_fetched_at = time.monotonic()
+    return _studies_cache_rows
+
+
+def _all_studies_query() -> tuple[tuple[tuple[str, object], ...], ...]:
+    """Return every study's full detail, refetched on-demand if the cache is
+    missing or older than STUDIES_CACHE_TTL_SECONDS.
+
+    Mirrors cbioportal's own /api/studies?projection=DETAILED, which caches
+    the entire study list rather than one entry per distinct query shape.
+    list_studies() filters this single snapshot in Python by search/limit/
+    verbose, so every call is a cache hit regardless of the search term used.
+
+    In steady state the background loop in main() keeps this fresh before
+    TTL ever expires (see STUDIES_CACHE_REFRESH_INTERVAL_SECONDS), so this
+    on-demand path is normally only exercised on the very first call after a
+    cold start, or if that background loop has stalled.
 
     Holds the lock across the refetch (not just the cache read) so concurrent
     callers past TTL expiry queue behind one refresh instead of each firing
     their own identical ClickHouse query.
     """
-    global _studies_cache_rows, _studies_cache_fetched_at
     with _studies_cache_lock:
         now = time.monotonic()
         if (
@@ -953,23 +989,30 @@ def _all_studies_query() -> tuple[tuple[tuple[str, object], ...], ...]:
         ):
             return _studies_cache_rows
 
-        query = """
-                    SELECT
-                        cs.cancer_study_identifier,
-                        cs.name,
-                        cs.description,
-                        cs.type_of_cancer_id,
-                        COUNT(DISTINCT s.internal_id) as sample_count
-                    FROM cancer_study cs
-                    LEFT JOIN patient p ON p.cancer_study_id = cs.cancer_study_id
-                    LEFT JOIN sample s ON s.patient_id = p.internal_id
-                    GROUP BY cs.cancer_study_identifier, cs.name, cs.description, cs.type_of_cancer_id
-                    ORDER BY sample_count DESC
-                """
-        rows = run_select_query(query)
-        _studies_cache_rows = tuple(tuple(row.items()) for row in rows)
-        _studies_cache_fetched_at = now
-        return _studies_cache_rows
+        return _fetch_and_store_studies()
+
+
+def _refresh_studies_cache_once() -> None:
+    """Run a single proactive background refresh cycle. Best-effort: a
+    failed fetch is logged and left for the next cycle rather than raised,
+    so one bad refresh doesn't take down the background loop.
+    """
+    try:
+        with _studies_cache_lock:
+            _fetch_and_store_studies()
+    except Exception as e:
+        logger.warning(f"Background list_studies cache refresh failed: {e}")
+
+
+def _refresh_studies_cache_forever() -> None:
+    """Background loop: proactively refetch the study cache every
+    STUDIES_CACHE_REFRESH_INTERVAL_SECONDS for the life of the process. Runs
+    on a daemon thread started from main(); see that call site for how this
+    combines with the initial startup warm-up.
+    """
+    while True:
+        time.sleep(STUDIES_CACHE_REFRESH_INTERVAL_SECONDS)
+        _refresh_studies_cache_once()
 
 
 def _filter_studies(search: str | None, limit: int, verbose: bool) -> list[dict]:

--- a/src/cbioportal_mcp/server.py
+++ b/src/cbioportal_mcp/server.py
@@ -237,6 +237,15 @@ def main():
         logger.critical("❌ ClickHouse permission check failed: %s", e)
         sys.exit(2)
 
+    # Pre-warm the list_studies cache so the first real client request
+    # doesn't pay the ClickHouse round trip _all_studies_query() would
+    # otherwise incur on first use. Best-effort: a failure here just means
+    # the cache stays cold and warms lazily on first use, same as before.
+    try:
+        _all_studies_query()
+    except Exception as e:
+        logger.warning(f"Failed to pre-warm list_studies cache: {e}")
+
     # Set up OpenTelemetry → Datadog agent (no-op if env vars not set or agent unreachable)
     provider = configure_telemetry()
     if provider is not None:

--- a/src/cbioportal_mcp/server.py
+++ b/src/cbioportal_mcp/server.py
@@ -19,6 +19,8 @@ import json
 import logging
 import re
 import sys
+import threading
+import time
 from functools import lru_cache
 from importlib import resources as importlib_resources
 from pathlib import Path
@@ -237,14 +239,17 @@ def main():
         logger.critical("❌ ClickHouse permission check failed: %s", e)
         sys.exit(2)
 
-    # Pre-warm the list_studies cache so the first real client request
-    # doesn't pay the ClickHouse round trip _all_studies_query() would
-    # otherwise incur on first use. Best-effort: a failure here just means
-    # the cache stays cold and warms lazily on first use, same as before.
-    try:
-        _all_studies_query()
-    except Exception as e:
-        logger.warning(f"Failed to pre-warm list_studies cache: {e}")
+    # Warm the list_studies cache in the background so most early callers get
+    # a warm cache without blocking server startup on the ClickHouse round
+    # trip. Best-effort and fire-and-forget: a failure here just means the
+    # cache warms lazily on first real use instead, same as before this ran.
+    def _warm_studies_cache():
+        try:
+            _all_studies_query()
+        except Exception as e:
+            logger.warning(f"Failed to pre-warm list_studies cache: {e}")
+
+    threading.Thread(target=_warm_studies_cache, daemon=True).start()
 
     # Set up OpenTelemetry → Datadog agent (no-op if env vars not set or agent unreachable)
     provider = configure_telemetry()
@@ -903,35 +908,68 @@ WHERE cancer_study_identifier = '{study_id}'
 MAX_LIST_LIMIT = 100
 
 
-@lru_cache(maxsize=1)
+# How long a cached study snapshot is served before the next call refetches it.
+# The underlying data only changes via the daily clone job, so this just bounds
+# how long a study add/remove can take to become visible without a restart.
+STUDIES_CACHE_TTL_SECONDS = 900
+
+_studies_cache_lock = threading.Lock()
+_studies_cache_rows: tuple[tuple[tuple[str, object], ...], ...] | None = None
+_studies_cache_fetched_at: float = 0.0
+
+
+def _clear_studies_cache() -> None:
+    """Reset the cached study snapshot. Test hook; not used at runtime."""
+    global _studies_cache_rows, _studies_cache_fetched_at
+    with _studies_cache_lock:
+        _studies_cache_rows = None
+        _studies_cache_fetched_at = 0.0
+
+
 def _all_studies_query() -> tuple[tuple[tuple[str, object], ...], ...]:
-    """Return every study's full detail, cached once for the process lifetime.
+    """Return every study's full detail, refetched at most every
+    STUDIES_CACHE_TTL_SECONDS.
 
     Mirrors cbioportal's own /api/studies?projection=DETAILED, which caches
     the entire study list rather than one entry per distinct query shape.
     list_studies() filters this single snapshot in Python by search/limit/
-    verbose, so every call is a cache hit after the first regardless of the
-    search term used.
+    verbose, so every call is a cache hit regardless of the search term used,
+    except for the one caller per TTL window that pays the refetch.
 
     Use sample/patient for counts instead of clinical_data_derived. The latter
     has many clinical-attribute rows per sample and makes first-connect study
     discovery slower than it needs to be.
+
+    Holds the lock across the refetch (not just the cache read) so concurrent
+    callers past TTL expiry queue behind one refresh instead of each firing
+    their own identical ClickHouse query.
     """
-    query = """
-                SELECT
-                    cs.cancer_study_identifier,
-                    cs.name,
-                    cs.description,
-                    cs.type_of_cancer_id,
-                    COUNT(DISTINCT s.internal_id) as sample_count
-                FROM cancer_study cs
-                LEFT JOIN patient p ON p.cancer_study_id = cs.cancer_study_id
-                LEFT JOIN sample s ON s.patient_id = p.internal_id
-                GROUP BY cs.cancer_study_identifier, cs.name, cs.description, cs.type_of_cancer_id
-                ORDER BY sample_count DESC
-            """
-    rows = run_select_query(query)
-    return tuple(tuple(row.items()) for row in rows)
+    global _studies_cache_rows, _studies_cache_fetched_at
+    with _studies_cache_lock:
+        now = time.monotonic()
+        if (
+            _studies_cache_rows is not None
+            and (now - _studies_cache_fetched_at) < STUDIES_CACHE_TTL_SECONDS
+        ):
+            return _studies_cache_rows
+
+        query = """
+                    SELECT
+                        cs.cancer_study_identifier,
+                        cs.name,
+                        cs.description,
+                        cs.type_of_cancer_id,
+                        COUNT(DISTINCT s.internal_id) as sample_count
+                    FROM cancer_study cs
+                    LEFT JOIN patient p ON p.cancer_study_id = cs.cancer_study_id
+                    LEFT JOIN sample s ON s.patient_id = p.internal_id
+                    GROUP BY cs.cancer_study_identifier, cs.name, cs.description, cs.type_of_cancer_id
+                    ORDER BY sample_count DESC
+                """
+        rows = run_select_query(query)
+        _studies_cache_rows = tuple(tuple(row.items()) for row in rows)
+        _studies_cache_fetched_at = now
+        return _studies_cache_rows
 
 
 def _filter_studies(search: str | None, limit: int, verbose: bool) -> list[dict]:

--- a/src/cbioportal_mcp/server.py
+++ b/src/cbioportal_mcp/server.py
@@ -911,8 +911,51 @@ WHERE cancer_study_identifier = '{study_id}'
 # Maximum allowed limit for list queries to prevent expensive unbounded queries
 MAX_LIST_LIMIT = 100
 
+
+@lru_cache(maxsize=128)
+def _list_studies_query(
+    search: str | None, limit: int, verbose: bool
+) -> tuple[tuple[tuple[str, object], ...], ...]:
+    """Return cached study rows for list_studies.
+
+    Use sample/patient for counts instead of clinical_data_derived. The latter
+    has many clinical-attribute rows per sample and makes first-connect study
+    discovery slower than it needs to be.
+    """
+    description_select = ",\n                    cs.description" if verbose else ""
+    description_group = ", cs.description" if verbose else ""
+
+    if search:
+        safe_search = _sanitize_search_term(search)
+        where_clause = f"""
+                WHERE cs.cancer_study_identifier ILIKE '%{safe_search}%'
+                    OR cs.name ILIKE '%{safe_search}%'
+                    OR cs.type_of_cancer_id ILIKE '%{safe_search}%'
+                    OR cs.description ILIKE '%{safe_search}%'
+        """
+    else:
+        where_clause = ""
+
+    query = f"""
+                SELECT
+                    cs.cancer_study_identifier,
+                    cs.name{description_select},
+                    cs.type_of_cancer_id,
+                    COUNT(DISTINCT s.internal_id) as sample_count
+                FROM cancer_study cs
+                LEFT JOIN patient p ON p.cancer_study_id = cs.cancer_study_id
+                LEFT JOIN sample s ON s.patient_id = p.internal_id
+                {where_clause}
+                GROUP BY cs.cancer_study_identifier, cs.name, cs.type_of_cancer_id{description_group}
+                ORDER BY sample_count DESC
+                LIMIT {limit}
+            """
+    rows = run_select_query(query)
+    return tuple(tuple(row.items()) for row in rows)
+
+
 @mcp.tool()
-def list_studies(search: str = None, limit: int = 20) -> list[dict]:
+def list_studies(search: str = None, limit: int = 20, verbose: bool = False) -> list[dict]:
     """List available cBioPortal studies.
 
     Studies with pre-generated guides (in resources/study-guides/) will have has_guide=True.
@@ -920,9 +963,11 @@ def list_studies(search: str = None, limit: int = 20) -> list[dict]:
     Args:
         search: Optional search term to filter studies by name, identifier, cancer type, or description
         limit: Maximum number of studies to return (default 20, max 100)
+        verbose: Include longer study description text. Defaults to false for faster first-connect discovery.
 
     Returns:
-        List of studies with their identifiers, names, descriptions, sample counts, and guide availability
+        List of studies with identifiers, names, cancer types, sample counts, and guide availability.
+        Descriptions are included only when verbose=true.
     """
     available_guides = set(_list_available_study_guides())
     
@@ -930,42 +975,8 @@ def list_studies(search: str = None, limit: int = 20) -> list[dict]:
     safe_limit = max(1, min(int(limit), MAX_LIST_LIMIT))
     
     try:
-        if search:
-            # Sanitize search term to prevent SQL injection
-            safe_search = _sanitize_search_term(search)
-            query = f"""
-                SELECT
-                    cs.cancer_study_identifier,
-                    cs.name,
-                    cs.description,
-                    cs.type_of_cancer_id,
-                    COUNT(DISTINCT cd.sample_unique_id) as sample_count
-                FROM cancer_study cs
-                LEFT JOIN clinical_data_derived cd ON cs.cancer_study_identifier = cd.cancer_study_identifier
-                WHERE cs.cancer_study_identifier ILIKE '%{safe_search}%'
-                    OR cs.name ILIKE '%{safe_search}%'
-                    OR cs.type_of_cancer_id ILIKE '%{safe_search}%'
-                    OR cs.description ILIKE '%{safe_search}%'
-                GROUP BY cs.cancer_study_identifier, cs.name, cs.description, cs.type_of_cancer_id
-                ORDER BY sample_count DESC
-                LIMIT {safe_limit}
-            """
-        else:
-            query = f"""
-                SELECT
-                    cs.cancer_study_identifier,
-                    cs.name,
-                    cs.description,
-                    cs.type_of_cancer_id,
-                    COUNT(DISTINCT cd.sample_unique_id) as sample_count
-                FROM cancer_study cs
-                LEFT JOIN clinical_data_derived cd ON cs.cancer_study_identifier = cd.cancer_study_identifier
-                GROUP BY cs.cancer_study_identifier, cs.name, cs.description, cs.type_of_cancer_id
-                ORDER BY sample_count DESC
-                LIMIT {safe_limit}
-            """
-        
-        results = run_select_query(query)
+        cached_rows = _list_studies_query(search, safe_limit, bool(verbose))
+        results = [dict(row) for row in cached_rows]
         
         # Add has_guide field
         for study in results:

--- a/src/cbioportal_mcp/server.py
+++ b/src/cbioportal_mcp/server.py
@@ -82,24 +82,6 @@ def _validate_table_name(table: str) -> str:
         )
     return table
 
-def _sanitize_search_term(search: str) -> str:
-    """Sanitize a search term by escaping SQL special characters.
-    
-    Args:
-        search: The search term to sanitize
-        
-    Returns:
-        The sanitized search term safe for use in LIKE clauses
-    """
-    if not search:
-        return ""
-    # Escape single quotes by doubling them (SQL standard)
-    # Also escape % and _ which are LIKE wildcards
-    sanitized = search.replace("'", "''")
-    sanitized = sanitized.replace("%", "\\%")
-    sanitized = sanitized.replace("_", "\\_")
-    return sanitized
-
 # Resource loading using importlib.resources for proper package support
 def _get_resources_path() -> Path:
     """Get the resources directory path, supporting both installed packages and dev mode."""
@@ -912,46 +894,59 @@ WHERE cancer_study_identifier = '{study_id}'
 MAX_LIST_LIMIT = 100
 
 
-@lru_cache(maxsize=128)
-def _list_studies_query(
-    search: str | None, limit: int, verbose: bool
-) -> tuple[tuple[tuple[str, object], ...], ...]:
-    """Return cached study rows for list_studies.
+@lru_cache(maxsize=1)
+def _all_studies_query() -> tuple[tuple[tuple[str, object], ...], ...]:
+    """Return every study's full detail, cached once for the process lifetime.
+
+    Mirrors cbioportal's own /api/studies?projection=DETAILED, which caches
+    the entire study list rather than one entry per distinct query shape.
+    list_studies() filters this single snapshot in Python by search/limit/
+    verbose, so every call is a cache hit after the first regardless of the
+    search term used.
 
     Use sample/patient for counts instead of clinical_data_derived. The latter
     has many clinical-attribute rows per sample and makes first-connect study
     discovery slower than it needs to be.
     """
-    description_select = ",\n                    cs.description" if verbose else ""
-    description_group = ", cs.description" if verbose else ""
-
-    if search:
-        safe_search = _sanitize_search_term(search)
-        where_clause = f"""
-                WHERE cs.cancer_study_identifier ILIKE '%{safe_search}%'
-                    OR cs.name ILIKE '%{safe_search}%'
-                    OR cs.type_of_cancer_id ILIKE '%{safe_search}%'
-                    OR cs.description ILIKE '%{safe_search}%'
-        """
-    else:
-        where_clause = ""
-
-    query = f"""
+    query = """
                 SELECT
                     cs.cancer_study_identifier,
-                    cs.name{description_select},
+                    cs.name,
+                    cs.description,
                     cs.type_of_cancer_id,
                     COUNT(DISTINCT s.internal_id) as sample_count
                 FROM cancer_study cs
                 LEFT JOIN patient p ON p.cancer_study_id = cs.cancer_study_id
                 LEFT JOIN sample s ON s.patient_id = p.internal_id
-                {where_clause}
-                GROUP BY cs.cancer_study_identifier, cs.name, cs.type_of_cancer_id{description_group}
+                GROUP BY cs.cancer_study_identifier, cs.name, cs.description, cs.type_of_cancer_id
                 ORDER BY sample_count DESC
-                LIMIT {limit}
             """
     rows = run_select_query(query)
     return tuple(tuple(row.items()) for row in rows)
+
+
+def _filter_studies(search: str | None, limit: int, verbose: bool) -> list[dict]:
+    """Filter, limit, and shape the cached full study list for list_studies()."""
+    rows = [dict(row) for row in _all_studies_query()]
+
+    if search:
+        needle = search.lower()
+        rows = [
+            row
+            for row in rows
+            if needle in row["cancer_study_identifier"].lower()
+            or needle in row["name"].lower()
+            or needle in row["type_of_cancer_id"].lower()
+            or needle in (row["description"] or "").lower()
+        ]
+
+    rows = rows[:limit]
+
+    if not verbose:
+        for row in rows:
+            row.pop("description", None)
+
+    return rows
 
 
 @mcp.tool()
@@ -975,9 +970,8 @@ def list_studies(search: str = None, limit: int = 20, verbose: bool = False) -> 
     safe_limit = max(1, min(int(limit), MAX_LIST_LIMIT))
     
     try:
-        cached_rows = _list_studies_query(search, safe_limit, bool(verbose))
-        results = [dict(row) for row in cached_rows]
-        
+        results = _filter_studies(search, safe_limit, bool(verbose))
+
         # Add has_guide field
         for study in results:
             study_id = study.get('cancer_study_identifier', '')

--- a/tests/test_list_studies_performance.py
+++ b/tests/test_list_studies_performance.py
@@ -1,0 +1,76 @@
+from cbioportal_mcp import server
+
+
+def test_list_studies_default_uses_trimmed_sample_count_query(monkeypatch):
+    queries = []
+
+    def fake_run_select_query(query):
+        queries.append(query)
+        return [
+            {
+                "cancer_study_identifier": "study_alpha",
+                "name": "Alpha Study",
+                "type_of_cancer_id": "brca",
+                "sample_count": 10,
+            }
+        ]
+
+    server._list_studies_query.cache_clear()
+    monkeypatch.setattr(server, "_list_available_study_guides", lambda: [])
+    monkeypatch.setattr(server, "run_select_query", fake_run_select_query)
+
+    rows = server.list_studies.fn()
+
+    assert rows[0]["cancer_study_identifier"] == "study_alpha"
+    assert "description" not in rows[0]
+    assert "clinical_data_derived" not in queries[0]
+    assert "LEFT JOIN sample" in queries[0]
+    assert "LEFT JOIN patient" in queries[0]
+
+
+def test_list_studies_caches_repeated_calls(monkeypatch):
+    call_count = 0
+
+    def fake_run_select_query(query):
+        nonlocal call_count
+        call_count += 1
+        return [
+            {
+                "cancer_study_identifier": "study_alpha",
+                "name": "Alpha Study",
+                "type_of_cancer_id": "brca",
+                "sample_count": 10,
+            }
+        ]
+
+    server._list_studies_query.cache_clear()
+    monkeypatch.setattr(server, "_list_available_study_guides", lambda: [])
+    monkeypatch.setattr(server, "run_select_query", fake_run_select_query)
+
+    assert server.list_studies.fn(limit=20) == server.list_studies.fn(limit=20)
+    assert call_count == 1
+
+
+def test_list_studies_verbose_includes_description(monkeypatch):
+    queries = []
+
+    def fake_run_select_query(query):
+        queries.append(query)
+        return [
+            {
+                "cancer_study_identifier": "study_alpha",
+                "name": "Alpha Study",
+                "description": "Long description",
+                "type_of_cancer_id": "brca",
+                "sample_count": 10,
+            }
+        ]
+
+    server._list_studies_query.cache_clear()
+    monkeypatch.setattr(server, "_list_available_study_guides", lambda: [])
+    monkeypatch.setattr(server, "run_select_query", fake_run_select_query)
+
+    rows = server.list_studies.fn(verbose=True)
+
+    assert rows[0]["description"] == "Long description"
+    assert "cs.description" in queries[0]

--- a/tests/test_list_studies_performance.py
+++ b/tests/test_list_studies_performance.py
@@ -1,21 +1,26 @@
 from cbioportal_mcp import server
 
 
+def _fake_rows():
+    return [
+        {
+            "cancer_study_identifier": "study_alpha",
+            "name": "Alpha Study",
+            "description": "Long description",
+            "type_of_cancer_id": "brca",
+            "sample_count": 10,
+        }
+    ]
+
+
 def test_list_studies_default_uses_trimmed_sample_count_query(monkeypatch):
     queries = []
 
     def fake_run_select_query(query):
         queries.append(query)
-        return [
-            {
-                "cancer_study_identifier": "study_alpha",
-                "name": "Alpha Study",
-                "type_of_cancer_id": "brca",
-                "sample_count": 10,
-            }
-        ]
+        return _fake_rows()
 
-    server._list_studies_query.cache_clear()
+    server._all_studies_query.cache_clear()
     monkeypatch.setattr(server, "_list_available_study_guides", lambda: [])
     monkeypatch.setattr(server, "run_select_query", fake_run_select_query)
 
@@ -28,26 +33,22 @@ def test_list_studies_default_uses_trimmed_sample_count_query(monkeypatch):
     assert "LEFT JOIN patient" in queries[0]
 
 
-def test_list_studies_caches_repeated_calls(monkeypatch):
+def test_list_studies_caches_repeated_calls_across_search_terms(monkeypatch):
     call_count = 0
 
     def fake_run_select_query(query):
         nonlocal call_count
         call_count += 1
-        return [
-            {
-                "cancer_study_identifier": "study_alpha",
-                "name": "Alpha Study",
-                "type_of_cancer_id": "brca",
-                "sample_count": 10,
-            }
-        ]
+        return _fake_rows()
 
-    server._list_studies_query.cache_clear()
+    server._all_studies_query.cache_clear()
     monkeypatch.setattr(server, "_list_available_study_guides", lambda: [])
     monkeypatch.setattr(server, "run_select_query", fake_run_select_query)
 
     assert server.list_studies.fn(limit=20) == server.list_studies.fn(limit=20)
+    # A never-before-seen search term still hits the same cached snapshot,
+    # unlike the old per-query-shape cache which would have missed here.
+    server.list_studies.fn(search="alpha")
     assert call_count == 1
 
 
@@ -56,17 +57,9 @@ def test_list_studies_verbose_includes_description(monkeypatch):
 
     def fake_run_select_query(query):
         queries.append(query)
-        return [
-            {
-                "cancer_study_identifier": "study_alpha",
-                "name": "Alpha Study",
-                "description": "Long description",
-                "type_of_cancer_id": "brca",
-                "sample_count": 10,
-            }
-        ]
+        return _fake_rows()
 
-    server._list_studies_query.cache_clear()
+    server._all_studies_query.cache_clear()
     monkeypatch.setattr(server, "_list_available_study_guides", lambda: [])
     monkeypatch.setattr(server, "run_select_query", fake_run_select_query)
 
@@ -74,3 +67,31 @@ def test_list_studies_verbose_includes_description(monkeypatch):
 
     assert rows[0]["description"] == "Long description"
     assert "cs.description" in queries[0]
+
+
+def test_list_studies_search_filters_in_python(monkeypatch):
+    def fake_run_select_query(query):
+        return [
+            {
+                "cancer_study_identifier": "study_alpha",
+                "name": "Alpha Study",
+                "description": "Long description",
+                "type_of_cancer_id": "brca",
+                "sample_count": 10,
+            },
+            {
+                "cancer_study_identifier": "study_beta",
+                "name": "Beta Study",
+                "description": None,
+                "type_of_cancer_id": "luad",
+                "sample_count": 5,
+            },
+        ]
+
+    server._all_studies_query.cache_clear()
+    monkeypatch.setattr(server, "_list_available_study_guides", lambda: [])
+    monkeypatch.setattr(server, "run_select_query", fake_run_select_query)
+
+    rows = server.list_studies.fn(search="beta")
+
+    assert [row["cancer_study_identifier"] for row in rows] == ["study_beta"]

--- a/tests/test_list_studies_performance.py
+++ b/tests/test_list_studies_performance.py
@@ -97,6 +97,51 @@ def test_list_studies_verbose_includes_description(monkeypatch):
     assert "cs.description" in queries[0]
 
 
+def test_background_refresh_updates_cache_without_a_live_caller(monkeypatch):
+    call_count = 0
+
+    def fake_run_select_query(query):
+        nonlocal call_count
+        call_count += 1
+        return _fake_rows()
+
+    fake_now = [1000.0]
+    monkeypatch.setattr(server.time, "monotonic", lambda: fake_now[0])
+
+    server._clear_studies_cache()
+    monkeypatch.setattr(server, "run_select_query", fake_run_select_query)
+
+    server._refresh_studies_cache_once()
+    assert call_count == 1
+
+    # Advance well past STUDIES_CACHE_TTL_SECONDS with no caller in between --
+    # the on-demand path would refetch here, but nothing calls it.
+    fake_now[0] += 2000
+
+    # The background cycle refreshes on its own, with no list_studies() call
+    # driving it.
+    server._refresh_studies_cache_once()
+    assert call_count == 2
+
+    # A caller landing right after sees the already-fresh cache, not a third
+    # fetch triggered by its own request.
+    monkeypatch.setattr(server, "_list_available_study_guides", lambda: [])
+    server.list_studies.fn()
+    assert call_count == 2
+
+
+def test_background_refresh_failure_is_logged_not_raised(monkeypatch, caplog):
+    def failing_run_select_query(query):
+        raise RuntimeError("clickhouse unreachable")
+
+    server._clear_studies_cache()
+    monkeypatch.setattr(server, "run_select_query", failing_run_select_query)
+
+    server._refresh_studies_cache_once()
+
+    assert "Background list_studies cache refresh failed" in caplog.text
+
+
 def test_list_studies_search_filters_in_python(monkeypatch):
     def fake_run_select_query(query):
         return [

--- a/tests/test_list_studies_performance.py
+++ b/tests/test_list_studies_performance.py
@@ -20,7 +20,7 @@ def test_list_studies_default_uses_trimmed_sample_count_query(monkeypatch):
         queries.append(query)
         return _fake_rows()
 
-    server._all_studies_query.cache_clear()
+    server._clear_studies_cache()
     monkeypatch.setattr(server, "_list_available_study_guides", lambda: [])
     monkeypatch.setattr(server, "run_select_query", fake_run_select_query)
 
@@ -33,6 +33,34 @@ def test_list_studies_default_uses_trimmed_sample_count_query(monkeypatch):
     assert "LEFT JOIN patient" in queries[0]
 
 
+def test_list_studies_refetches_after_ttl_expires(monkeypatch):
+    call_count = 0
+
+    def fake_run_select_query(query):
+        nonlocal call_count
+        call_count += 1
+        return _fake_rows()
+
+    fake_now = [1000.0]
+    monkeypatch.setattr(server.time, "monotonic", lambda: fake_now[0])
+    monkeypatch.setattr(server, "STUDIES_CACHE_TTL_SECONDS", 900)
+
+    server._clear_studies_cache()
+    monkeypatch.setattr(server, "_list_available_study_guides", lambda: [])
+    monkeypatch.setattr(server, "run_select_query", fake_run_select_query)
+
+    server.list_studies.fn()
+    assert call_count == 1
+
+    fake_now[0] += 899  # still within TTL
+    server.list_studies.fn()
+    assert call_count == 1
+
+    fake_now[0] += 2  # past TTL
+    server.list_studies.fn()
+    assert call_count == 2
+
+
 def test_list_studies_caches_repeated_calls_across_search_terms(monkeypatch):
     call_count = 0
 
@@ -41,7 +69,7 @@ def test_list_studies_caches_repeated_calls_across_search_terms(monkeypatch):
         call_count += 1
         return _fake_rows()
 
-    server._all_studies_query.cache_clear()
+    server._clear_studies_cache()
     monkeypatch.setattr(server, "_list_available_study_guides", lambda: [])
     monkeypatch.setattr(server, "run_select_query", fake_run_select_query)
 
@@ -59,7 +87,7 @@ def test_list_studies_verbose_includes_description(monkeypatch):
         queries.append(query)
         return _fake_rows()
 
-    server._all_studies_query.cache_clear()
+    server._clear_studies_cache()
     monkeypatch.setattr(server, "_list_available_study_guides", lambda: [])
     monkeypatch.setattr(server, "run_select_query", fake_run_select_query)
 
@@ -88,7 +116,7 @@ def test_list_studies_search_filters_in_python(monkeypatch):
             },
         ]
 
-    server._all_studies_query.cache_clear()
+    server._clear_studies_cache()
     monkeypatch.setattr(server, "_list_available_study_guides", lambda: [])
     monkeypatch.setattr(server, "run_select_query", fake_run_select_query)
 


### PR DESCRIPTION
## Summary

**This is an interim fix.** It makes `list_studies()` fast via app-level caching, not by fixing the two underlying root causes — see "Known limitations."

- Lighter default response: omit `description` unless `verbose=true`.
- Faster sample counts: direct `patient`/`sample` count instead of `clinical_data_derived`.
- Whole study list cached (TTL 15 min), filtered by `search`/`limit`/`verbose` in Python, warmed in a background thread at startup.
- Tests for query shape, verbose behavior, cache reuse, TTL expiry, and search filtering.

## Behavioral changes

This PR is intentionally not a fully behavior-neutral performance change. The main `list_studies` behavior is preserved, but the default response is lighter and the sample-count source changes.

- `list_studies()` now omits `description` by default to reduce response size and first-connect latency.
- Callers that need descriptions can request the previous fuller shape with `verbose=true`.
- `sample_count` is now computed from `cancer_study -> patient -> sample` instead of `clinical_data_derived`.
  - This avoids scanning many clinical-attribute rows per sample.
  - Counts may differ from the previous implementation if a sample exists without corresponding clinical-derived rows, or vice versa.
- The full, unfiltered study list (all columns, all rows) is cached in-process and served for up to `STUDIES_CACHE_TTL_SECONDS` (15 min) before the next call refetches it; `search`, `limit`, and `verbose` are then applied in Python against that cached snapshot.
  - Earlier revision of this PR cached per `(search, limit, verbose)` combination instead, which meant any new search term was a guaranteed cache miss. Caching the whole dataset avoids that, at the cost of always fetching descriptions for every study on each refetch.
  - Earlier revision of this PR cached indefinitely (`lru_cache`, no expiry) — a study added or removed by the daily clone job would've been invisible until the process restarted. TTL bounds that staleness window instead of requiring a restart, while still avoiding a DB round trip on every call.
  - The refetch holds a lock across the ClickHouse round trip (not just the cache read), so concurrent callers past TTL expiry queue behind one refresh instead of each firing an identical query.
- `main()` warms `_all_studies_query()` in a background daemon thread at startup (right after `ensure_db_permissions()` confirms DB connectivity), instead of blocking `mcp.run()` on the ClickHouse round trip. Best-effort and fire-and-forget: if the warm-up query fails, it's logged and the cache falls back to warming lazily on first real use — startup never fails or waits on it.
- Search behavior is functionally the same fields (study identifier, name, cancer type, description) but is now a case-insensitive Python substring match instead of a SQL `ILIKE`, since filtering happens after the single cached fetch rather than per-query.
- Limit behavior remains the same: default `20`, clamped to `MAX_LIST_LIMIT = 100`.
- Sorting remains by descending `sample_count`.
- `has_guide` is still added after query execution.

Fixes #109.

## Testing

- `uv run --with pytest pytest tests/test_list_studies_performance.py -q` — covers default (non-verbose) query shape, verbose description inclusion, Python-side search filtering, that a previously-unseen search term still reuses the cached snapshot (`call_count == 1` across two different `list_studies()` calls with different `search` values), and that the cache refetches once TTL elapses but not before (mocks `time.monotonic`).
- `uv run --with pytest pytest tests/ -q` — full suite; one pre-existing, unrelated failure in `tests/test_auth.py::test_builds_google_provider_when_all_three_set` (reproduces on this branch prior to this commit; `tests/test_auth.py` is not touched here).

### Latency benchmark (real ClickHouse Cloud, 511 studies, measured 2026-08-20)

Ran `list_studies()`/`_all_studies_query()` directly against a live ClickHouse Cloud instance (not mocked), 5 cold samples / 20 warm samples per case:

| Case | min | mean | max |
|---|---|---|---|
| cold — `_all_studies_query()`, cache cleared each call | 270.47ms | 348.95ms | 627.52ms |
| warm — `list_studies.fn()`, repeat call (cache hit) | 0.16ms | 0.18ms | 0.22ms |
| warm — `list_studies.fn(search=<never-seen term>)` | 0.46ms | 0.52ms | 0.60ms |
| warm — `list_studies.fn(verbose=True)` (cache hit) | 0.12ms | 0.13ms | 0.15ms |

For reference, cbioportal's own `/api/studies?projection=DETAILED` (public, always-warm server-side cache, ~540KB body) measured ~145–190ms steady-state over 5 calls from this same environment.

Takeaways:
- Once warm, we're ~250–1500x faster than cbioportal's own endpoint (sub-millisecond vs ~150–190ms), for any args — the `warm — search=<never-seen term>` row confirms the fix: an unseen search term no longer costs a DB round trip, unlike the old per-`(search, limit, verbose)` cache this PR replaces.
- The cold path measured above (~270–290ms steady-state, vs cbioportal's ~150–190ms) is what any caller pays once per `STUDIES_CACHE_TTL_SECONDS` (15 min) window, or once at startup via the background warm-up. Of that, roughly 65ms is `mcp_clickhouse` creating a new ClickHouse client/TLS handshake per call and ~200–220ms is the actual query + fetch of all 511 rows with descriptions — see "Known limitations" below, neither is fixed by this PR.
- The startup warm-up runs in a background thread rather than blocking `mcp.run()`, so in a long-lived deployment (HTTP/SSE, one process serving many clients) most real clients should see a warm cache without server readiness depending on ClickHouse latency. In a per-session `stdio` deployment (a fresh process per client), the warm-up racing the client's first request is a wash either way — it doesn't block startup, but it also doesn't guarantee the first call is warm; it's a net win specifically when a process outlives a single session.

### Known limitations — why this is an interim fix, not the root-cause fix

Caching and warming the query is a mitigation, not a fix, for why the cold path is ~270–290ms instead of comparable to cbioportal's ~150–190ms. Two real costs remain unaddressed, both outside `cbioportal-mcp`'s own code, and both are needed before this stops being a stopgap:

- **No connection reuse**: `mcp_clickhouse.run_select_query()` calls `create_clickhouse_client()` fresh on every invocation (visible in the benchmark logs — "Creating ClickHouse client connection" fires every call), costing ~65ms of TLS/auth setup per query, not just for `list_studies`. This lives in the third-party `mcp_clickhouse` dependency, not this repo.
- **No precomputed `sample_count`**: `_all_studies_query()` still does a live `COUNT(DISTINCT s.internal_id)` over a `patient`/`sample` join on every cache refresh. The `sql/` directory already has precedent for shipping derived views applied by the daily clone job (`sql/4-mutation-frequency-views.sql`, `sql/5-gene-expression-views.sql`), but those are plain `VIEW`s ("hold no data, just the query definition" per that file's own comment) — a real fix needs a precomputed table populated during the clone, which is a bigger change to the clone pipeline (`knowledgesystems-k8s-deployment`) that I can't safely author or validate without ClickHouse admin access to that pipeline.





