### PR TITLE
Add Datadog MCP tool metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,37 @@ export CLICKHOUSE_MCP_SERVER_TRANSPORT=stdio # or http or sse
 # export CLICKHOUSE_MCP_HTTP_PATH=/db/mcp
 ```
 
+### Datadog Tool Metrics
+
+The server emits one OpenTelemetry span per MCP tool call and can also emit
+DogStatsD metrics for dashboard-level aggregates:
+
+| Metric | Type | Purpose |
+|---|---|---|
+| `cbioportal_mcp.tool.calls` | counter | Tool-call volume by `tool`, `success`, `client_kind`, and `client_name` |
+| `cbioportal_mcp.tool.duration_ms` | distribution | Tool latency, including p50/p95/p99 by tool |
+| `cbioportal_mcp.tool.errors` | counter | Tool-call failures by tool/client |
+
+DogStatsD metrics are enabled by default when `DD_AGENT_HOST` or
+`DD_DOGSTATSD_HOST` is configured:
+
+```bash
+export DD_AGENT_HOST=<datadog-agent-host>
+# Optional overrides:
+export DD_DOGSTATSD_HOST=<dogstatsd-host>
+export DD_DOGSTATSD_PORT=8125
+export DD_SERVICE=cbioportal-mcp
+export DD_ENV=prod
+export CBIOPORTAL_MCP_DD_METRICS_ENABLED=true
+export CBIOPORTAL_MCP_DD_METRIC_PREFIX=cbioportal_mcp
+```
+
+Set `CBIOPORTAL_MCP_DD_METRICS_ENABLED=false` to disable DogStatsD metrics.
+The checked-in dashboard definition at
+[`datadog/cbioagent-tool-metrics-dashboard.json`](datadog/cbioagent-tool-metrics-dashboard.json)
+can be imported into Datadog or used as the source for updating the existing
+cBioAgent dashboard.
+
 ## Preparing the database
 
 **We strongly recommend pointing the MCP at a *separate* ClickHouse database, not your production cBioPortal database directly.** Two reasons:

--- a/datadog/cbioagent-tool-metrics-dashboard.json
+++ b/datadog/cbioagent-tool-metrics-dashboard.json
@@ -1,0 +1,306 @@
+{
+  "title": "cBioAgent MCP Tool Metrics",
+  "description": "MCP tool call frequency, latency, and error metrics emitted by cbioportal-mcp DogStatsD telemetry.",
+  "layout_type": "ordered",
+  "template_variables": [
+    {
+      "name": "env",
+      "prefix": "env",
+      "default": "*"
+    },
+    {
+      "name": "service",
+      "prefix": "service",
+      "default": "cbioportal-mcp"
+    },
+    {
+      "name": "client_kind",
+      "prefix": "client_kind",
+      "default": "*"
+    }
+  ],
+  "widgets": [
+    {
+      "definition": {
+        "title": "MCP Tool Metrics",
+        "background_color": "vivid_green",
+        "show_title": true,
+        "type": "group",
+        "layout_type": "ordered",
+        "widgets": [
+          {
+            "definition": {
+              "type": "note",
+              "content": "Tool metrics come from DogStatsD counters/distributions: `cbioportal_mcp.tool.calls`, `cbioportal_mcp.tool.duration_ms`, and `cbioportal_mcp.tool.errors`. Tags: `tool`, `success`, `client_kind`, `client_name`, `service`, `env`.",
+              "background_color": "blue",
+              "font_size": "14",
+              "text_align": "left",
+              "vertical_align": "center",
+              "show_tick": false,
+              "tick_pos": "50%",
+              "tick_edge": "left"
+            },
+            "layout": {
+              "x": 0,
+              "y": 0,
+              "width": 12,
+              "height": 1
+            }
+          },
+          {
+            "definition": {
+              "type": "query_value",
+              "title": "Total Tool Calls",
+              "requests": [
+                {
+                  "q": "sum:cbioportal_mcp.tool.calls{$env,$service,$client_kind}.as_count()",
+                  "aggregator": "sum"
+                }
+              ],
+              "autoscale": true,
+              "precision": 0
+            },
+            "layout": {
+              "x": 0,
+              "y": 1,
+              "width": 3,
+              "height": 2
+            }
+          },
+          {
+            "definition": {
+              "type": "query_value",
+              "title": "Tool Error Rate",
+              "requests": [
+                {
+                  "formulas": [
+                    {
+                      "formula": "100 * errors / calls"
+                    }
+                  ],
+                  "queries": [
+                    {
+                      "data_source": "metrics",
+                      "name": "errors",
+                      "query": "sum:cbioportal_mcp.tool.errors{$env,$service,$client_kind}.as_count()"
+                    },
+                    {
+                      "data_source": "metrics",
+                      "name": "calls",
+                      "query": "sum:cbioportal_mcp.tool.calls{$env,$service,$client_kind}.as_count()"
+                    }
+                  ],
+                  "response_format": "scalar"
+                }
+              ],
+              "autoscale": true,
+              "precision": 2,
+              "custom_unit": "%"
+            },
+            "layout": {
+              "x": 3,
+              "y": 1,
+              "width": 3,
+              "height": 2
+            }
+          },
+          {
+            "definition": {
+              "type": "timeseries",
+              "title": "Tool Calls by Tool",
+              "requests": [
+                {
+                  "q": "sum:cbioportal_mcp.tool.calls{$env,$service,$client_kind} by {tool}.as_count()",
+                  "display_type": "bars"
+                }
+              ],
+              "show_legend": true
+            },
+            "layout": {
+              "x": 6,
+              "y": 1,
+              "width": 6,
+              "height": 2
+            }
+          },
+          {
+            "definition": {
+              "type": "toplist",
+              "title": "Most Frequently Called Tools",
+              "requests": [
+                {
+                  "q": "top(sum:cbioportal_mcp.tool.calls{$env,$service,$client_kind} by {tool}.as_count(), 10, 'sum', 'desc')"
+                }
+              ]
+            },
+            "layout": {
+              "x": 0,
+              "y": 3,
+              "width": 4,
+              "height": 3
+            }
+          },
+          {
+            "definition": {
+              "type": "toplist",
+              "title": "Slowest Tools by p95 Latency",
+              "requests": [
+                {
+                  "q": "top(p95:cbioportal_mcp.tool.duration_ms{$env,$service,$client_kind} by {tool}, 10, 'last', 'desc')"
+                }
+              ]
+            },
+            "layout": {
+              "x": 4,
+              "y": 3,
+              "width": 4,
+              "height": 3
+            }
+          },
+          {
+            "definition": {
+              "type": "toplist",
+              "title": "Slowest Tools by p99 Latency",
+              "requests": [
+                {
+                  "q": "top(p99:cbioportal_mcp.tool.duration_ms{$env,$service,$client_kind} by {tool}, 10, 'last', 'desc')"
+                }
+              ]
+            },
+            "layout": {
+              "x": 8,
+              "y": 3,
+              "width": 4,
+              "height": 3
+            }
+          },
+          {
+            "definition": {
+              "type": "query_table",
+              "title": "Tool Cost Ranking: Volume and Latency",
+              "requests": [
+                {
+                  "response_format": "scalar",
+                  "queries": [
+                    {
+                      "name": "calls",
+                      "data_source": "metrics",
+                      "query": "sum:cbioportal_mcp.tool.calls{$env,$service,$client_kind} by {tool}.as_count()"
+                    },
+                    {
+                      "name": "avg_latency",
+                      "data_source": "metrics",
+                      "query": "avg:cbioportal_mcp.tool.duration_ms{$env,$service,$client_kind} by {tool}"
+                    },
+                    {
+                      "name": "p95_latency",
+                      "data_source": "metrics",
+                      "query": "p95:cbioportal_mcp.tool.duration_ms{$env,$service,$client_kind} by {tool}"
+                    }
+                  ],
+                  "formulas": [
+                    {
+                      "formula": "calls",
+                      "alias": "calls"
+                    },
+                    {
+                      "formula": "avg_latency",
+                      "alias": "avg latency ms"
+                    },
+                    {
+                      "formula": "p95_latency",
+                      "alias": "p95 latency ms"
+                    },
+                    {
+                      "formula": "calls * avg_latency",
+                      "alias": "total tool time ms"
+                    }
+                  ],
+                  "sort": {
+                    "count": 10,
+                    "order_by": [
+                      {
+                        "type": "formula",
+                        "index": 3,
+                        "order": "desc"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "layout": {
+              "x": 0,
+              "y": 6,
+              "width": 12,
+              "height": 4
+            }
+          },
+          {
+            "definition": {
+              "type": "timeseries",
+              "title": "p95 Latency by Tool",
+              "requests": [
+                {
+                  "q": "p95:cbioportal_mcp.tool.duration_ms{$env,$service,$client_kind} by {tool}",
+                  "display_type": "line"
+                }
+              ],
+              "show_legend": true
+            },
+            "layout": {
+              "x": 0,
+              "y": 10,
+              "width": 6,
+              "height": 3
+            }
+          },
+          {
+            "definition": {
+              "type": "timeseries",
+              "title": "Tool Calls by Client Kind",
+              "requests": [
+                {
+                  "q": "sum:cbioportal_mcp.tool.calls{$env,$service,$client_kind} by {client_kind}.as_count()",
+                  "display_type": "bars"
+                }
+              ],
+              "show_legend": true
+            },
+            "layout": {
+              "x": 6,
+              "y": 10,
+              "width": 3,
+              "height": 3
+            }
+          },
+          {
+            "definition": {
+              "type": "timeseries",
+              "title": "Tool Errors by Tool",
+              "requests": [
+                {
+                  "q": "sum:cbioportal_mcp.tool.errors{$env,$service,$client_kind} by {tool}.as_count()",
+                  "display_type": "bars"
+                }
+              ],
+              "show_legend": true
+            },
+            "layout": {
+              "x": 9,
+              "y": 10,
+              "width": 3,
+              "height": 3
+            }
+          }
+        ]
+      },
+      "layout": {
+        "x": 0,
+        "y": 0,
+        "width": 12,
+        "height": 14
+      }
+    }
+  ]
+}

--- a/src/cbioportal_mcp/server.py
+++ b/src/cbioportal_mcp/server.py
@@ -31,7 +31,11 @@ import mcp.types as mt
 from cbioportal_mcp.env import get_mcp_config, TransportType
 from cbioportal_mcp.authentication.permissions import ensure_db_permissions
 from cbioportal_mcp.auth import _build_auth_provider
-from cbioportal_mcp.telemetry import configure_telemetry, TelemetryMiddleware
+from cbioportal_mcp.telemetry import (
+    TelemetryMiddleware,
+    configure_telemetry,
+    dogstatsd_metrics_configured,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -255,9 +259,11 @@ def main():
         logger.critical("❌ ClickHouse permission check failed: %s", e)
         sys.exit(2)
 
-    # Set up OpenTelemetry → Datadog agent (no-op if env vars not set or agent unreachable)
+    # Set up OpenTelemetry → Datadog agent (no-op if env vars not set or agent unreachable).
+    # DogStatsD tool metrics can still use the same middleware when only the
+    # Datadog agent's UDP endpoint is configured.
     provider = configure_telemetry()
-    if provider is not None:
+    if provider is not None or dogstatsd_metrics_configured():
         mcp.add_middleware(TelemetryMiddleware())
 
     transport = config.mcp_server_transport

--- a/src/cbioportal_mcp/telemetry.py
+++ b/src/cbioportal_mcp/telemetry.py
@@ -6,19 +6,144 @@ import atexit
 import json
 import logging
 import os
-from typing import Any
+import socket
+import time
 
 import mcp.types as mt
-from fastmcp.server.middleware import Middleware, MiddlewareContext, CallNext
+from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
 from opentelemetry import trace
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
-from opentelemetry.sdk.resources import Resource, SERVICE_NAME
+from opentelemetry.sdk.resources import SERVICE_NAME, Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
 logger = logging.getLogger(__name__)
 
 _tracer_provider: TracerProvider | None = None
+_dogstatsd_client: "_DogStatsDClient | None" = None
+
+
+def _env_flag(name: str, default: bool) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return value.strip().lower() not in {"0", "false", "no", "off"}
+
+
+def _sanitize_datadog_tag_value(value: object) -> str:
+    """Keep DogStatsD tags low-risk and parseable."""
+    text = str(value).strip().lower()
+    return "".join(ch if ch.isalnum() or ch in "._-/" else "_" for ch in text) or "unknown"
+
+
+class _DogStatsDClient:
+    """Minimal DogStatsD UDP client.
+
+    We only need counters and distributions, so using the wire protocol avoids
+    adding a dependency solely for a couple of metric packets per tool call.
+    """
+
+    def __init__(
+        self,
+        host: str,
+        port: int,
+        *,
+        prefix: str = "cbioportal_mcp",
+        constant_tags: dict[str, object] | None = None,
+    ) -> None:
+        self._address = (host, port)
+        self._prefix = prefix.rstrip(".")
+        self._constant_tags = constant_tags or {}
+        self._socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+
+    def increment(self, metric: str, tags: dict[str, object]) -> None:
+        self._send(metric, 1, "c", tags)
+
+    def distribution(self, metric: str, value: float, tags: dict[str, object]) -> None:
+        self._send(metric, value, "d", tags)
+
+    def _send(
+        self,
+        metric: str,
+        value: float | int,
+        metric_type: str,
+        tags: dict[str, object],
+    ) -> None:
+        full_metric = f"{self._prefix}.{metric}"
+        merged_tags = {**self._constant_tags, **tags}
+        tag_parts = [
+            f"{key}:{_sanitize_datadog_tag_value(value)}"
+            for key, value in sorted(merged_tags.items())
+            if value is not None
+        ]
+        tag_suffix = f"|#{','.join(tag_parts)}" if tag_parts else ""
+        packet = f"{full_metric}:{value}|{metric_type}{tag_suffix}"
+        self._socket.sendto(packet.encode("utf-8"), self._address)
+
+
+def _build_dogstatsd_client() -> _DogStatsDClient | None:
+    if not _env_flag("CBIOPORTAL_MCP_DD_METRICS_ENABLED", True):
+        return None
+
+    host = os.getenv("DD_DOGSTATSD_HOST") or os.getenv("DD_AGENT_HOST", "localhost")
+    port = int(os.getenv("DD_DOGSTATSD_PORT", "8125"))
+    prefix = os.getenv("CBIOPORTAL_MCP_DD_METRIC_PREFIX", "cbioportal_mcp")
+    service_name = os.getenv("DD_SERVICE") or os.getenv("OTEL_SERVICE_NAME", "cbioportal-mcp")
+    constant_tags: dict[str, object] = {"service": service_name}
+    if os.getenv("DD_ENV"):
+        constant_tags["env"] = os.getenv("DD_ENV")
+
+    return _DogStatsDClient(host, port, prefix=prefix, constant_tags=constant_tags)
+
+
+def dogstatsd_metrics_configured() -> bool:
+    """Return true when tool metrics should enable the telemetry middleware."""
+    if not _env_flag("CBIOPORTAL_MCP_DD_METRICS_ENABLED", True):
+        return False
+    return bool(
+        os.getenv("DD_AGENT_HOST")
+        or os.getenv("DD_DOGSTATSD_HOST")
+        or os.getenv("CBIOPORTAL_MCP_DD_METRICS_ENABLED")
+    )
+
+
+def _get_dogstatsd_client() -> _DogStatsDClient | None:
+    global _dogstatsd_client
+    if _dogstatsd_client is None:
+        try:
+            _dogstatsd_client = _build_dogstatsd_client()
+        except Exception as exc:
+            logger.debug("DogStatsD client setup failed: %s", exc)
+            _dogstatsd_client = None
+    return _dogstatsd_client
+
+
+def _emit_tool_metrics(
+    *,
+    tool_name: str,
+    duration_ms: float,
+    success: bool,
+    client_kind: str,
+    client_name: str | None,
+) -> None:
+    """Emit aggregate Datadog metrics for MCP tool call frequency and latency."""
+    client = _get_dogstatsd_client()
+    if client is None:
+        return
+
+    tags = {
+        "tool": tool_name,
+        "success": str(success).lower(),
+        "client_kind": client_kind,
+        "client_name": client_name,
+    }
+    try:
+        client.increment("tool.calls", tags)
+        client.distribution("tool.duration_ms", round(duration_ms, 3), tags)
+        if not success:
+            client.increment("tool.errors", tags)
+    except Exception as exc:
+        logger.debug("DogStatsD metric emit failed: %s", exc)
 
 
 def configure_telemetry() -> TracerProvider | None:
@@ -300,7 +425,10 @@ def _llmobs_finish(span, result, *, error: bool) -> None:
             try:
                 if hasattr(result, "content"):
                     output = json.dumps(
-                        [c.model_dump() if hasattr(c, "model_dump") else str(c) for c in result.content],
+                        [
+                            c.model_dump() if hasattr(c, "model_dump") else str(c)
+                            for c in result.content
+                        ],
                         default=str,
                     )
                 else:
@@ -378,6 +506,7 @@ class TelemetryMiddleware(Middleware):
             client_version,
             session_id,
         )
+        started = time.perf_counter()
 
         with self._tracer.start_as_current_span(f"mcp.tool/{tool_name}") as span:
             span.set_attribute("mcp.tool.name", tool_name)
@@ -403,12 +532,30 @@ class TelemetryMiddleware(Middleware):
 
             try:
                 result = await call_next(context)
+                duration_ms = (time.perf_counter() - started) * 1000
+                span.set_attribute("mcp.tool.duration_ms", duration_ms)
                 span.set_attribute("mcp.tool.success", True)
+                _emit_tool_metrics(
+                    tool_name=tool_name,
+                    duration_ms=duration_ms,
+                    success=True,
+                    client_kind=client,
+                    client_name=client_name,
+                )
                 _llmobs_finish(llmobs_span, result, error=False)
                 return result
             except Exception as exc:
+                duration_ms = (time.perf_counter() - started) * 1000
+                span.set_attribute("mcp.tool.duration_ms", duration_ms)
                 span.set_attribute("mcp.tool.success", False)
                 span.set_attribute("error.type", type(exc).__name__)
                 span.record_exception(exc)
+                _emit_tool_metrics(
+                    tool_name=tool_name,
+                    duration_ms=duration_ms,
+                    success=False,
+                    client_kind=client,
+                    client_name=client_name,
+                )
                 _llmobs_finish(llmobs_span, None, error=True)
                 raise

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -53,5 +53,6 @@ def test_builds_google_provider_when_all_three_set():
         client_id=_ALL_GOOGLE_ENV["CBIOPORTAL_MCP_GOOGLE_CLIENT_ID"],
         client_secret=_ALL_GOOGLE_ENV["CBIOPORTAL_MCP_GOOGLE_CLIENT_SECRET"],
         base_url=_ALL_GOOGLE_ENV["CBIOPORTAL_MCP_GOOGLE_BASE_URL"],
+        required_scopes=["openid", "email", "profile"],
         require_authorization_consent=False,
     )

--- a/tests/test_datadog_dashboard.py
+++ b/tests/test_datadog_dashboard.py
@@ -1,0 +1,18 @@
+import json
+from pathlib import Path
+
+
+def test_tool_metrics_dashboard_json_is_valid_and_references_metrics():
+    dashboard = json.loads(
+        Path("datadog/cbioagent-tool-metrics-dashboard.json").read_text(encoding="utf-8")
+    )
+    serialized = json.dumps(dashboard)
+
+    assert dashboard["title"] == "cBioAgent MCP Tool Metrics"
+    assert dashboard["widgets"][0]["definition"]["title"] == "MCP Tool Metrics"
+    assert dashboard["widgets"][0]["definition"]["type"] == "group"
+    assert "cbioportal_mcp.tool.calls" in serialized
+    assert "cbioportal_mcp.tool.duration_ms" in serialized
+    assert "cbioportal_mcp.tool.errors" in serialized
+    assert "tool" in serialized
+    assert "client_kind" in serialized

--- a/tests/test_telemetry_user_id.py
+++ b/tests/test_telemetry_user_id.py
@@ -1,15 +1,22 @@
 import base64
+from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
+import pytest
 from fastmcp.server.auth import AccessToken
 from mcp.types import Implementation
 
 from cbioportal_mcp.telemetry import (
+    TelemetryMiddleware,
+    _DogStatsDClient,
+    _emit_tool_metrics,
     _extract_mcp_client_info,
     _extract_oauth_identity,
     _extract_session_id,
     _extract_user_identity,
     _resolve_caller_identity,
+    _sanitize_datadog_tag_value,
+    dogstatsd_metrics_configured,
 )
 
 
@@ -166,3 +173,179 @@ def test_resolve_caller_identity_direct_when_neither_present():
         user_id, user_email, client = _resolve_caller_identity()
         assert user_id is None
         assert client == "direct"
+
+
+def test_dogstatsd_metrics_configured_when_agent_host_present(monkeypatch):
+    monkeypatch.setenv("DD_AGENT_HOST", "10.0.0.1")
+    monkeypatch.delenv("CBIOPORTAL_MCP_DD_METRICS_ENABLED", raising=False)
+
+    assert dogstatsd_metrics_configured() is True
+
+
+def test_dogstatsd_metrics_can_be_disabled(monkeypatch):
+    monkeypatch.setenv("DD_AGENT_HOST", "10.0.0.1")
+    monkeypatch.setenv("CBIOPORTAL_MCP_DD_METRICS_ENABLED", "false")
+
+    assert dogstatsd_metrics_configured() is False
+
+
+def test_sanitizes_datadog_tag_values():
+    assert (
+        _sanitize_datadog_tag_value("ClickHouse Run Select Query")
+        == "clickhouse_run_select_query"
+    )
+    assert _sanitize_datadog_tag_value("Claude Code/1.2") == "claude_code/1.2"
+    assert _sanitize_datadog_tag_value("") == "unknown"
+
+
+def test_dogstatsd_client_emits_counter_and_distribution_packets():
+    sent_packets = []
+
+    class FakeSocket:
+        def sendto(self, packet, address):
+            sent_packets.append((packet.decode("utf-8"), address))
+
+    with patch("socket.socket", return_value=FakeSocket()):
+        client = _DogStatsDClient(
+            "127.0.0.1",
+            8125,
+            prefix="cbioportal_mcp",
+            constant_tags={"service": "cbioportal-mcp", "env": "prod"},
+        )
+        client.increment("tool.calls", {"tool": "list_studies", "success": "true"})
+        client.distribution("tool.duration_ms", 12.345, {"tool": "list_studies"})
+
+    assert sent_packets == [
+        (
+            "cbioportal_mcp.tool.calls:1|c|#env:prod,service:cbioportal-mcp,success:true,tool:list_studies",
+            ("127.0.0.1", 8125),
+        ),
+        (
+            "cbioportal_mcp.tool.duration_ms:12.345|d|#env:prod,service:cbioportal-mcp,tool:list_studies",
+            ("127.0.0.1", 8125),
+        ),
+    ]
+
+
+def test_emit_tool_metrics_tags_call_latency_and_errors():
+    calls = []
+
+    class FakeDogStatsD:
+        def increment(self, metric, tags):
+            calls.append(("increment", metric, tags))
+
+        def distribution(self, metric, value, tags):
+            calls.append(("distribution", metric, value, tags))
+
+    with patch("cbioportal_mcp.telemetry._get_dogstatsd_client", return_value=FakeDogStatsD()):
+        _emit_tool_metrics(
+            tool_name="list_studies",
+            duration_ms=12.34567,
+            success=False,
+            client_kind="direct",
+            client_name="claude-code",
+        )
+
+    assert calls == [
+        (
+            "increment",
+            "tool.calls",
+            {
+                "tool": "list_studies",
+                "success": "false",
+                "client_kind": "direct",
+                "client_name": "claude-code",
+            },
+        ),
+        (
+            "distribution",
+            "tool.duration_ms",
+            12.346,
+            {
+                "tool": "list_studies",
+                "success": "false",
+                "client_kind": "direct",
+                "client_name": "claude-code",
+            },
+        ),
+        (
+            "increment",
+            "tool.errors",
+            {
+                "tool": "list_studies",
+                "success": "false",
+                "client_kind": "direct",
+                "client_name": "claude-code",
+            },
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_telemetry_middleware_emits_success_tool_metrics():
+    emitted = []
+    middleware = TelemetryMiddleware()
+    context = SimpleNamespace(
+        message=SimpleNamespace(name="ping", arguments={}),
+        fastmcp_context=None,
+    )
+
+    async def call_next(_context):
+        return "pong"
+
+    with (
+        patch(
+            "cbioportal_mcp.telemetry._resolve_caller_identity",
+            return_value=(None, None, "direct"),
+        ),
+        patch("cbioportal_mcp.telemetry._extract_mcp_client_info", return_value=("codex", "0.1")),
+        patch("cbioportal_mcp.telemetry._extract_session_id", return_value=None),
+        patch("cbioportal_mcp.telemetry._llmobs_tool_span", return_value=None),
+        patch(
+            "cbioportal_mcp.telemetry._emit_tool_metrics",
+            side_effect=lambda **kwargs: emitted.append(kwargs),
+        ),
+    ):
+        result = await middleware.on_call_tool(context, call_next)
+
+    assert result == "pong"
+    assert emitted[0]["tool_name"] == "ping"
+    assert emitted[0]["success"] is True
+    assert emitted[0]["client_kind"] == "direct"
+    assert emitted[0]["client_name"] == "codex"
+    assert emitted[0]["duration_ms"] >= 0
+
+
+@pytest.mark.asyncio
+async def test_telemetry_middleware_emits_failure_tool_metrics():
+    emitted = []
+    middleware = TelemetryMiddleware()
+    context = SimpleNamespace(
+        message=SimpleNamespace(name="ping", arguments={}),
+        fastmcp_context=None,
+    )
+
+    async def call_next(_context):
+        raise RuntimeError("boom")
+
+    with (
+        patch(
+            "cbioportal_mcp.telemetry._resolve_caller_identity",
+            return_value=(None, None, "direct"),
+        ),
+        patch("cbioportal_mcp.telemetry._extract_mcp_client_info", return_value=(None, None)),
+        patch("cbioportal_mcp.telemetry._extract_session_id", return_value=None),
+        patch("cbioportal_mcp.telemetry._llmobs_tool_span", return_value=None),
+        patch(
+            "cbioportal_mcp.telemetry._emit_tool_metrics",
+            side_effect=lambda **kwargs: emitted.append(kwargs),
+        ),
+    ):
+        with pytest.raises(RuntimeError, match="boom"):
+            await middleware.on_call_tool(context, call_next)
+
+    assert emitted[0]["tool_name"] == "ping"
+    assert emitted[0]["success"] is False
+    assert emitted[0]["client_kind"] == "direct"
+    assert emitted[0]["client_name"] is None
+    assert emitted[0]["duration_ms"] >= 0


### PR DESCRIPTION
## Summary
- emit DogStatsD counters/distributions for MCP tool call volume, latency, and errors
- enable telemetry middleware when only DogStatsD is configured
- add a grouped Datadog dashboard JSON section for tool frequency/latency ranking and document the env vars
- update the stale GoogleProvider test expectation for current required scopes so the full suite passes

## Validation
- uv run pytest -q
- uv run ruff check src/cbioportal_mcp/telemetry.py tests/test_datadog_dashboard.py tests/test_auth.py
- git diff --check
- updated Datadog dashboard 5vb-9a4-723 in Chrome and reloaded it; verified MCP Tool Metrics, Slowest Tools by p95 Latency, Tool Cost Ranking, and client_kind persisted