### PR TITLE
Add by_profile_type projection to genetic_alteration_derived

### DIFF
--- a/sql/6-genetic-alteration-projection.sql
+++ b/sql/6-genetic-alteration-projection.sql
@@ -1,0 +1,39 @@
+-- ============================================================================
+-- Alternative-order projection for genetic_alteration_derived
+-- ============================================================================
+-- genetic_alteration_derived (10.29B rows / 28.1 GiB) is sorted by
+-- (cancer_study_identifier, hugo_gene_symbol, profile_type, sample_unique_id).
+-- Queries that filter on profile_type without constraining an earlier
+-- sort-key column (e.g. "which samples have an mrna_median_Zscores profile")
+-- force a full-table scan even for a single-value equality check, because
+-- profile_type is only the third sort-key column.
+--
+-- A five-day trace of the llm_user ClickHouse account found nine such
+-- queries responsible for 293s/week (49.3% of total execution time) --
+-- see the P99 query-optimization report:
+-- https://gist.github.com/alisman/9cda4965ba6b20ed1abcb3e432a6d1c2
+--
+-- A projection stores a second physical copy of the table sorted by an
+-- alternative key; ClickHouse picks whichever ordering serves the query.
+--
+-- Trade-offs -- read before applying:
+--   - Roughly doubles on-disk size for this table (~28 GiB -> ~56 GiB).
+--   - MATERIALIZE PROJECTION is a heavy one-time mutation over 10.29B rows;
+--     run it during a low-traffic window.
+--   - sql/README.md notes these files re-apply on EVERY daily clone (the
+--     CronJob clones a fresh DB, then re-runs sql/*.sql against it). That
+--     means this materialization is NOT one-time in production -- it re-runs
+--     in full on every daily clone. Confirm the daily cron window can absorb
+--     a 10.29B-row MATERIALIZE PROJECTION before merging this; if it can't,
+--     this needs a different mechanism (e.g. only materializing when the
+--     projection doesn't already exist on an incrementally-updated clone)
+--     rather than being applied as-is here.
+-- ============================================================================
+
+ALTER TABLE genetic_alteration_derived
+ADD PROJECTION IF NOT EXISTS by_profile_type (
+    SELECT *
+    ORDER BY (profile_type, hugo_gene_symbol, cancer_study_identifier, sample_unique_id)
+);
+
+ALTER TABLE genetic_alteration_derived MATERIALIZE PROJECTION by_profile_type;

--- a/sql/README.md
+++ b/sql/README.md
@@ -15,6 +15,7 @@ MCP agent can reason about it.
 | 3 | `3-add-cancer-study-query-preferences.sql` | Creates `cancer_study_query_preferences` table + pattern-detected preferences (currently `pan_cancer_tcga`). |
 | 4 | `4-mutation-frequency-views.sql` | Mutation-frequency parameterized views (`gene_mutation_frequency_by_cancer_type`, `top_mutated_genes_in_cohort`) and the two coverage building-block views (`mutation_panel_gene_coverage`, `mutation_wes_coverage`). Handles the "WES is not in `gene_panel`" trap that produces >100% frequencies. See `cbioportal://mutation-frequency-guide`. |
 | 5 | `5-gene-expression-views.sql` | Gene-expression / copy-number-value / methylation views, backed by `genetic_alteration_derived`. Currently `gene_pair_coexpression(study, gene_a, gene_b, profile_type)` for Spearman correlation between two genes. See `cbioportal://gene-expression-guide`. |
+| 6 | `6-genetic-alteration-projection.sql` | Adds a `by_profile_type` projection to `genetic_alteration_derived` so `profile_type`-only filters don't force a full 10.29B-row scan. Heavy: re-materializes on every daily clone -- see the trade-off note in the file before applying. |
 
 Everything under `sql/` directly is **portable** — works against any cBioPortal deployment. Deployment-specific SQL lives under `sql/portal-specific/<portal-name>/`:
 


### PR DESCRIPTION
## Summary

- Adds `sql/6-genetic-alteration-projection.sql`, a `by_profile_type` projection on `genetic_alteration_derived` ordered by `(profile_type, hugo_gene_symbol, cancer_study_identifier, sample_unique_id)`.
- Updates `sql/README.md`'s file table with the new entry.

## Why

`genetic_alteration_derived` (10.29B rows / 28.1 GiB) is sorted by `(cancer_study_identifier, hugo_gene_symbol, profile_type, sample_unique_id)`. A five-day trace of the `llm_user` ClickHouse account found nine queries filtering only on `profile_type` — the third sort-key column — that forced full-table scans even for single-value equality checks, costing ~293s/week (49.3% of total query execution time). Full analysis: [P99 query-optimization report](https://gist.github.com/alisman/9cda4965ba6b20ed1abcb3e432a6d1c2), Pattern A.

A projection stores a second physical copy of the table sorted by an alternative key so ClickHouse can pick whichever ordering serves the query.

## ⚠️ Needs infra sign-off before merge

- Roughly **doubles on-disk size** for this table (~28 GiB → ~56 GiB).
- `MATERIALIZE PROJECTION` is a heavy mutation over 10.29B rows — should run during a low-traffic window.
- Per `sql/README.md`, files in `sql/` re-apply on **every daily clone** (the CronJob clones a fresh DB, then re-runs `sql/*.sql`). That means this materialization is **not one-time** in production — it recurs in full on every daily clone. I'm flagging this rather than assuming it's fine: someone who owns `knowledgesystems-k8s-deployment` needs to confirm the daily cron window can absorb a 10.29B-row `MATERIALIZE PROJECTION`, or this needs a different mechanism (e.g. skip materialization when the projection already exists on an incrementally-updated clone).

## Testing

Can't be verified locally — this requires ClickHouse admin credentials against a prepped database. Per `sql/README.md`'s "Applying these files manually" section:

```bash
export CLICKHOUSE_HOST=...
export CLICKHOUSE_DATABASE=...
export CLICKHOUSE_ADMIN_USER=...
export CLICKHOUSE_ADMIN_PASSWORD=...
./scripts/apply_sql.sh
```