### PR TITLE
Add pitfall against resolving study IDs via fact-table subqueries

### DIFF
--- a/src/cbioportal_mcp/resources/common-pitfalls.md
+++ b/src/cbioportal_mcp/resources/common-pitfalls.md
@@ -372,6 +372,45 @@ FROM genomic_event_derived
 GROUP BY hugo_gene_symbol;
 ```
 
+### 10b. 🚨 RESOLVING STUDY IDENTIFIERS VIA A SUBQUERY ON A FACT TABLE
+
+`cancer_study` is a 539-row dimension table with every `cancer_study_identifier`
+in the deployment. `genetic_alteration_derived`, `genomic_event_derived`, and
+`clinical_data_derived` are multi-billion-row fact tables. Never use a fact
+table to look up which study identifiers match a pattern — resolve against
+`cancer_study` (or `list_studies()` / `search_oncotree()`) first.
+
+#### ❌ Wrong: subquery on a fact table just to find study identifiers
+```sql
+-- INCORRECT - scans the whole 10.29B-row fact table to resolve study IDs
+SELECT hugo_gene_symbol, alteration_value
+FROM genetic_alteration_derived
+WHERE cancer_study_identifier IN (
+    SELECT DISTINCT cancer_study_identifier
+    FROM genetic_alteration_derived
+    WHERE cancer_study_identifier LIKE '%brca%'
+)
+AND profile_type = 'mrna';
+```
+
+#### ✅ Correct: resolve against the small dimension table, then pass a literal list
+```sql
+-- Step 1: resolve against cancer_study (539 rows)
+SELECT cancer_study_identifier FROM cancer_study
+WHERE cancer_study_identifier LIKE '%brca%';
+
+-- Step 2: use the resolved identifiers as a literal IN (...) list
+SELECT hugo_gene_symbol, alteration_value
+FROM genetic_alteration_derived
+WHERE cancer_study_identifier IN ('brca_metabric', 'brca_tcga_pan_can_atlas_2018')
+AND profile_type = 'mrna';
+```
+
+**Key rule:** If you need to know *which* studies match something, ask
+`cancer_study` (or `list_studies`/`search_oncotree`), never a fact table —
+even a `DISTINCT` subquery still has to scan every row of the fact table to
+find the distinct values.
+
 ## CNA and Column Name Pitfalls
 
 ### 11. 🚨 CNA VALUES ARE NUMERIC, NOT STRINGS

--- a/src/cbioportal_mcp/resources/system-prompt.md
+++ b/src/cbioportal_mcp/resources/system-prompt.md
@@ -32,6 +32,7 @@ BEFORE ANSWERING ANY QUESTION, you MUST:
 - `search_oncotree` resolves abbreviations, deprecated codes, and common names to the correct OncoTree codes used in the `type_of_cancer` table
 - Example: "ALL" is a deprecated code — `search_oncotree("ALL")` returns BLL (B-Lymphoblastic Leukemia) and TLL (T-Lymphoblastic Leukemia) as the current codes
 - **Never use `LIKE '%abbreviation%'`** for cancer type matching — always resolve through OncoTree first
+- **Never resolve study identifiers via a subquery on a fact table** (`genetic_alteration_derived`, `genomic_event_derived`, `clinical_data_derived`) — always resolve against the small `cancer_study` table or `list_studies()` first, then pass the resolved identifiers as a literal `IN (...)` list. See `cbioportal://common-pitfalls` pitfall #10b
 - If `search_oncotree` returns multiple plausible matches, ask the user which cancer type they mean before querying
 - Use `list_studies(search)` for study discovery after resolving the cancer type
 - Also read `cbioportal://clinical-data-guide` for clinical data query patterns


### PR DESCRIPTION
## Summary

- Adds pitfall `10b` to `common-pitfalls.md`: never resolve `cancer_study_identifier` values via a subquery on a fact table (`genetic_alteration_derived`, `genomic_event_derived`, `clinical_data_derived`) — resolve against the 539-row `cancer_study` table (or `list_studies()`/`search_oncotree()`) first, then pass the resolved identifiers as a literal `IN (...)` list.
- Extends the existing system-prompt.md bullet ("Never use `LIKE '%abbreviation%'` for cancer type matching") to also cover study-identifier resolution, pointing at the new pitfall.

## Why

Thirteen gene-signature-correlation queries in the [P99 query-optimization report](https://gist.github.com/alisman/9cda4965ba6b20ed1abcb3e432a6d1c2) (Pattern C) scanned the 10.29B-row `genetic_alteration_derived` table with a `DISTINCT` subquery just to resolve which `cancer_study_identifier` values matched a pattern — work the 539-row `cancer_study` table can do directly. Costed ~49s/week (8.3% of total execution time). Even a `DISTINCT` subquery still has to scan every row of the fact table to compute the distinct values, so the fix is steering the agent to resolve against the small dimension table instead.

## Testing

```
uv run --with pytest pytest -q
```
57/57 tests pass, including `tests/test_guide_layer_issue_coverage.py` which asserts on guide content.