### PR TITLE
Tag SELECT queries by call site and parallelize get_study_guide

### DIFF
--- a/src/cbioportal_mcp/server.py
+++ b/src/cbioportal_mcp/server.py
@@ -19,6 +19,7 @@ import json
 import logging
 import re
 import sys
+from concurrent.futures import ThreadPoolExecutor
 from functools import lru_cache
 from importlib import resources as importlib_resources
 from pathlib import Path
@@ -35,6 +36,7 @@ from cbioportal_mcp.telemetry import (
     TelemetryMiddleware,
     configure_telemetry,
     dogstatsd_metrics_configured,
+    traced_db_query,
 )
 
 logger = logging.getLogger(__name__)
@@ -406,7 +408,7 @@ def study_resolution_guide() -> str:
 )
 def clickhouse_run_select_query(query: str) -> dict[str, list[dict] | str]:
     try:
-        result = run_select_query(query)
+        result = run_select_query(query, query_label="clickhouse_run_select_query")
         logger.debug(f"clickhouse_run_select_query returns {result}")
         return {"rows": result}
     except Exception as e:
@@ -484,12 +486,20 @@ def clickhouse_list_table_columns(table: str) -> dict[str, list[dict] | str]:
         return {"error_message": error_message}
 
 
-def run_select_query(query: str) -> list[dict]:
+def run_select_query(query: str, *, query_label: str) -> list[dict]:
     """
     Execute arbitrary ClickHouse SQL SELECT query.
-    
+
     Note: CTEs (WITH ... AS) are supported. Query validation is handled at the
     database level via read-only user permissions (see authentication/permissions.py).
+
+    Args:
+        query_label: Identifies the call site for telemetry (a Datadog span +
+            metric tag), e.g. "study_guide.counts". run_select_query() is a
+            single funnel for every SELECT this server runs, so without a
+            per-call-site label its own latency metric would average a cheap
+            lookup together with an expensive multi-table aggregate. Use
+            "area.purpose", not the raw SQL text.
 
     Returns:
         list: A list of rows, where each row is a dictionary with column names as keys and corresponding values.
@@ -499,8 +509,9 @@ def run_select_query(query: str) -> list[dict]:
     # DB-level read-only permissions (enforced on startup) prevent non-SELECT queries,
     # so we don't need application-level query filtering. This allows CTEs (WITH ... AS).
     logger.debug("run_select_query: delegate the query to run_select_query tool of ClickHouse MCP")
-    ch_query_result = run_select_query(query)
-    result = zip_select_query_result(ch_query_result)
+    with traced_db_query(query_label):
+        ch_query_result = run_select_query(query)
+        result = zip_select_query_result(ch_query_result)
     return result
 
 
@@ -668,7 +679,7 @@ def _similar_study_identifiers(study_id: str, limit: int = 10) -> list[dict]:
             FROM cancer_study
             WHERE {clauses}
             LIMIT {int(limit)}
-        """) or []
+        """, query_label="similar_study_identifiers") or []
     except Exception as e:
         logger.error(f"Error looking up studies similar to {study_id}: {e}")
         return []
@@ -763,7 +774,7 @@ def get_study_guide(study_id: str) -> str:
                 type_of_cancer_id
             FROM cancer_study
             WHERE lower(cancer_study_identifier) = lower('{study_id}')
-        """)
+        """, query_label="study_guide.study_info")
 
         if not study_info:
             return _study_not_in_deployment_message(study_id)
@@ -778,15 +789,95 @@ def get_study_guide(study_id: str) -> str:
 **Cancer Type:** {info.get('type_of_cancer_id', 'N/A')}
 **Description:** {info.get('description', 'N/A')}
 """)
-        
-        # 2. Patient and sample counts
-        counts = run_select_query(f"""
-            SELECT 
-                COUNT(DISTINCT patient_unique_id) as patient_count,
-                COUNT(DISTINCT sample_unique_id) as sample_count
-            FROM clinical_data_derived 
-            WHERE cancer_study_identifier = '{study_id}'
-        """)
+
+        # Sections 2-7 below only depend on study_id, not on each other or on
+        # section order, so they're fired concurrently here instead of one
+        # ClickHouse round trip at a time -- each pays the same fixed
+        # per-call connection overhead (see run_select_query), so six
+        # sequential calls cost roughly six times that overhead in wall
+        # clock, while six concurrent ones cost roughly one. Results are
+        # still consumed in the original section order below, so the guide's
+        # output is unchanged regardless of which query finishes first.
+        with ThreadPoolExecutor(max_workers=6) as executor:
+            counts_future = executor.submit(
+                run_select_query,
+                f"""
+                    SELECT
+                        COUNT(DISTINCT patient_unique_id) as patient_count,
+                        COUNT(DISTINCT sample_unique_id) as sample_count
+                    FROM clinical_data_derived
+                    WHERE cancer_study_identifier = '{study_id}'
+                """,
+                query_label="study_guide.counts",
+            )
+            profiles_future = executor.submit(
+                run_select_query,
+                f"""
+                    SELECT DISTINCT
+                        gp.genetic_alteration_type,
+                        gp.datatype,
+                        gp.name
+                    FROM genetic_profile gp
+                    JOIN cancer_study cs ON gp.cancer_study_id = cs.cancer_study_id
+                    WHERE cs.cancer_study_identifier = '{study_id}'
+                """,
+                query_label="study_guide.profiles",
+            )
+            panels_future = executor.submit(
+                run_select_query,
+                f"""
+                    SELECT DISTINCT gene_panel_id, COUNT(DISTINCT sample_unique_id) as sample_count
+                    FROM sample_to_gene_panel_derived
+                    WHERE cancer_study_identifier = '{study_id}'
+                    GROUP BY gene_panel_id
+                    ORDER BY sample_count DESC
+                    LIMIT 10
+                """,
+                query_label="study_guide.panels",
+            )
+            attrs_future = executor.submit(
+                run_select_query,
+                f"""
+                    SELECT DISTINCT attribute_name, COUNT(DISTINCT sample_unique_id) as coverage
+                    FROM clinical_data_derived
+                    WHERE cancer_study_identifier = '{study_id}'
+                    GROUP BY attribute_name
+                    ORDER BY coverage DESC
+                    LIMIT 20
+                """,
+                query_label="study_guide.attrs",
+            )
+            top_genes_future = executor.submit(
+                run_select_query,
+                f"""
+                    SELECT
+                        hugo_gene_symbol,
+                        COUNT(DISTINCT sample_unique_id) as altered_samples
+                    FROM genomic_event_derived
+                    WHERE cancer_study_identifier = '{study_id}'
+                        AND variant_type = 'mutation'
+                        AND mutation_status != 'UNCALLED'
+                    GROUP BY hugo_gene_symbol
+                    ORDER BY altered_samples DESC
+                    LIMIT 10
+                """,
+                query_label="study_guide.top_genes",
+            )
+            sample_types_future = executor.submit(
+                run_select_query,
+                f"""
+                    SELECT attribute_value as sample_type, COUNT(DISTINCT sample_unique_id) as count
+                    FROM clinical_data_derived
+                    WHERE cancer_study_identifier = '{study_id}'
+                        AND attribute_name = 'SAMPLE_TYPE'
+                    GROUP BY attribute_value
+                    ORDER BY count DESC
+                """,
+                query_label="study_guide.sample_types",
+            )
+
+            # 2. Patient and sample counts
+            counts = counts_future.result()
         if counts:
             c = counts[0]
             guide_sections.append(f"""## Cohort Statistics
@@ -795,15 +886,7 @@ def get_study_guide(study_id: str) -> str:
 """)
         
         # 3. Available data types
-        profiles = run_select_query(f"""
-            SELECT DISTINCT 
-                gp.genetic_alteration_type,
-                gp.datatype,
-                gp.name
-            FROM genetic_profile gp
-            JOIN cancer_study cs ON gp.cancer_study_id = cs.cancer_study_id
-            WHERE cs.cancer_study_identifier = '{study_id}'
-        """)
+        profiles = profiles_future.result()
         if profiles:
             guide_sections.append("## Available Data Types\n")
             for p in profiles:
@@ -811,14 +894,7 @@ def get_study_guide(study_id: str) -> str:
             guide_sections.append("")
         
         # 4. Gene panels used
-        panels = run_select_query(f"""
-            SELECT DISTINCT gene_panel_id, COUNT(DISTINCT sample_unique_id) as sample_count
-            FROM sample_to_gene_panel_derived
-            WHERE cancer_study_identifier = '{study_id}'
-            GROUP BY gene_panel_id
-            ORDER BY sample_count DESC
-            LIMIT 10
-        """)
+        panels = panels_future.result()
         if panels:
             guide_sections.append("## Gene Panels\n")
             for p in panels:
@@ -831,14 +907,7 @@ def get_study_guide(study_id: str) -> str:
             guide_sections.append("")
         
         # 5. Clinical attributes available
-        attrs = run_select_query(f"""
-            SELECT DISTINCT attribute_name, COUNT(DISTINCT sample_unique_id) as coverage
-            FROM clinical_data_derived
-            WHERE cancer_study_identifier = '{study_id}'
-            GROUP BY attribute_name
-            ORDER BY coverage DESC
-            LIMIT 20
-        """)
+        attrs = attrs_future.result()
         if attrs:
             guide_sections.append("## Available Clinical Attributes\n")
             guide_sections.append("| Attribute | Samples with Data |")
@@ -848,18 +917,7 @@ def get_study_guide(study_id: str) -> str:
             guide_sections.append("")
         
         # 6. Top mutated genes (if mutation data exists)
-        top_genes = run_select_query(f"""
-            SELECT 
-                hugo_gene_symbol,
-                COUNT(DISTINCT sample_unique_id) as altered_samples
-            FROM genomic_event_derived
-            WHERE cancer_study_identifier = '{study_id}'
-                AND variant_type = 'mutation'
-                AND mutation_status != 'UNCALLED'
-            GROUP BY hugo_gene_symbol
-            ORDER BY altered_samples DESC
-            LIMIT 10
-        """)
+        top_genes = top_genes_future.result()
         if top_genes:
             guide_sections.append("## Top Mutated Genes\n")
             guide_sections.append("| Gene | Altered Samples |")
@@ -869,14 +927,7 @@ def get_study_guide(study_id: str) -> str:
             guide_sections.append("")
         
         # 7. Sample type distribution
-        sample_types = run_select_query(f"""
-            SELECT attribute_value as sample_type, COUNT(DISTINCT sample_unique_id) as count
-            FROM clinical_data_derived
-            WHERE cancer_study_identifier = '{study_id}'
-                AND attribute_name = 'SAMPLE_TYPE'
-            GROUP BY attribute_value
-            ORDER BY count DESC
-        """)
+        sample_types = sample_types_future.result()
         if sample_types:
             guide_sections.append("## Sample Types\n")
             for st in sample_types:
@@ -971,7 +1022,7 @@ def list_studies(search: str = None, limit: int = 20) -> list[dict]:
                 LIMIT {safe_limit}
             """
         
-        results = run_select_query(query)
+        results = run_select_query(query, query_label="list_studies.query")
         
         # Add has_guide field
         for study in results:

--- a/src/cbioportal_mcp/telemetry.py
+++ b/src/cbioportal_mcp/telemetry.py
@@ -8,6 +8,7 @@ import logging
 import os
 import socket
 import time
+from contextlib import contextmanager
 
 import mcp.types as mt
 from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
@@ -144,6 +145,59 @@ def _emit_tool_metrics(
             client.increment("tool.errors", tags)
     except Exception as exc:
         logger.debug("DogStatsD metric emit failed: %s", exc)
+
+
+def _emit_db_query_metrics(
+    *,
+    query_label: str,
+    duration_ms: float,
+    success: bool,
+) -> None:
+    """Emit aggregate Datadog metrics for one ClickHouse SELECT, tagged by call
+    site. run_select_query() is a single funnel for every SELECT the server
+    runs; without a per-call-site tag its latency metric averages together a
+    cheap primary-key lookup and an expensive multi-table aggregate, hiding
+    which one actually needs attention."""
+    client = _get_dogstatsd_client()
+    if client is None:
+        return
+
+    tags = {"query_label": query_label, "success": str(success).lower()}
+    try:
+        client.increment("db_query.calls", tags)
+        client.distribution("db_query.duration_ms", round(duration_ms, 3), tags)
+        if not success:
+            client.increment("db_query.errors", tags)
+    except Exception as exc:
+        logger.debug("DogStatsD db_query metric emit failed: %s", exc)
+
+
+@contextmanager
+def traced_db_query(query_label: str):
+    """Wrap one ClickHouse SELECT with an OTel span (``db.query/<label>``) and
+    a Datadog distribution metric, both tagged by query_label so latency can
+    be broken down by call site in Datadog instead of averaged into one
+    run_select_query number. Re-raises on failure after recording it as a
+    failed call; does not suppress or alter the underlying exception.
+    """
+    tracer = trace.get_tracer(__name__)
+    started = time.perf_counter()
+    with tracer.start_as_current_span(f"db.query/{query_label}") as span:
+        span.set_attribute("db.query.label", query_label)
+        try:
+            yield
+        except Exception as exc:
+            duration_ms = (time.perf_counter() - started) * 1000
+            span.set_attribute("db.query.duration_ms", duration_ms)
+            span.set_attribute("db.query.success", False)
+            span.set_attribute("error.type", type(exc).__name__)
+            _emit_db_query_metrics(query_label=query_label, duration_ms=duration_ms, success=False)
+            raise
+        else:
+            duration_ms = (time.perf_counter() - started) * 1000
+            span.set_attribute("db.query.duration_ms", duration_ms)
+            span.set_attribute("db.query.success", True)
+            _emit_db_query_metrics(query_label=query_label, duration_ms=duration_ms, success=True)
 
 
 def configure_telemetry() -> TracerProvider | None:

--- a/tests/test_study_lookup.py
+++ b/tests/test_study_lookup.py
@@ -28,7 +28,7 @@ def fake_db(monkeypatch):
     """Stand in for ClickHouse: only the exact lowercase identifier is stored."""
     seen = []
 
-    def run_select_query(query: str):
+    def run_select_query(query: str, query_label=None):
         seen.append(" ".join(query.split()))
         q = query.lower()
         if "from cancer_study" in q and "lower(cancer_study_identifier) = lower(" in q:
@@ -63,7 +63,7 @@ def test_downstream_sections_use_the_canonical_identifier(fake_db):
 
 
 def test_miss_message_never_asserts_nonexistence(monkeypatch):
-    monkeypatch.setattr(server, "run_select_query", lambda q: [])
+    monkeypatch.setattr(server, "run_select_query", lambda q, query_label=None: [])
     out = _guide("totally_made_up_study")
 
     assert "does not exist" in out  # only as the instruction NOT to say it
@@ -72,7 +72,7 @@ def test_miss_message_never_asserts_nonexistence(monkeypatch):
 
 
 def test_miss_message_lists_the_three_recoverable_causes(monkeypatch):
-    monkeypatch.setattr(server, "run_select_query", lambda q: [])
+    monkeypatch.setattr(server, "run_select_query", lambda q, query_label=None: [])
     out = _guide("nbl_msk_9999")
 
     assert "Different identifier" in out
@@ -88,7 +88,7 @@ def test_miss_message_offers_similar_identifiers(fake_db):
 
 
 def test_similar_study_lookup_tolerates_a_db_error(monkeypatch):
-    def boom(query: str):
+    def boom(query: str, query_label=None):
         raise RuntimeError("clickhouse unavailable")
 
     monkeypatch.setattr(server, "run_select_query", boom)
@@ -96,8 +96,91 @@ def test_similar_study_lookup_tolerates_a_db_error(monkeypatch):
     assert server._similar_study_identifiers("nbl_msk_2023") == []
 
 
+def test_dynamic_guide_labels_each_query_by_call_site(monkeypatch):
+    """Every SELECT the dynamic guide issues must carry a distinct query_label,
+    so Datadog can break down latency by call site instead of averaging all
+    seven queries into one run_select_query number."""
+    labels_seen = []
+
+    def run_select_query(query: str, query_label=None):
+        labels_seen.append(query_label)
+        q = query.lower()
+        if "from cancer_study" in q and "lower(cancer_study_identifier) = lower(" in q:
+            return [CANCER_STUDY_ROW]
+        return []
+
+    monkeypatch.setattr(server, "run_select_query", run_select_query)
+    _guide("nbl_msk_2023")
+
+    assert set(labels_seen) == {
+        "study_guide.study_info",
+        "study_guide.counts",
+        "study_guide.profiles",
+        "study_guide.panels",
+        "study_guide.attrs",
+        "study_guide.top_genes",
+        "study_guide.sample_types",
+    }
+
+
+def test_dynamic_guide_section_order_is_stable_despite_concurrent_completion(monkeypatch):
+    """Sections 2-7 are fetched concurrently; whichever query finishes first must
+    not reorder the guide's markdown sections."""
+    import time as time_module
+
+    # Deliberately finish in the reverse of section order (sample_types first,
+    # counts last) to prove the assembled guide doesn't just reflect completion
+    # order.
+    delay_by_label = {
+        "study_guide.counts": 0.05,
+        "study_guide.profiles": 0.04,
+        "study_guide.panels": 0.03,
+        "study_guide.attrs": 0.02,
+        "study_guide.top_genes": 0.01,
+        "study_guide.sample_types": 0.0,
+    }
+
+    def run_select_query(query: str, query_label=None):
+        q = query.lower()
+        if "from cancer_study" in q and "lower(cancer_study_identifier) = lower(" in q:
+            return [CANCER_STUDY_ROW]
+        time_module.sleep(delay_by_label.get(query_label, 0.0))
+        if query_label == "study_guide.counts":
+            return [{"patient_count": 1, "sample_count": 2}]
+        if query_label == "study_guide.profiles":
+            return [{"genetic_alteration_type": "MUTATION_EXTENDED", "name": "Mutations"}]
+        if query_label == "study_guide.panels":
+            return [{"gene_panel_id": "WES", "sample_count": 2}]
+        if query_label == "study_guide.attrs":
+            return [{"attribute_name": "OS_MONTHS", "coverage": 2}]
+        if query_label == "study_guide.top_genes":
+            return [{"hugo_gene_symbol": "TP53", "altered_samples": 1}]
+        if query_label == "study_guide.sample_types":
+            return [{"sample_type": "Primary", "count": 2}]
+        return []
+
+    monkeypatch.setattr(server, "run_select_query", run_select_query)
+    out = _guide("nbl_msk_2023")
+
+    sections = [
+        "## Cohort Statistics",
+        "## Available Data Types",
+        "## Gene Panels",
+        "## Available Clinical Attributes",
+        "## Top Mutated Genes",
+        "## Sample Types",
+    ]
+    positions = [out.index(s) for s in sections]
+    assert positions == sorted(positions), (
+        "guide sections were reordered by which query finished first"
+    )
+
+
 def test_similar_study_lookup_ignores_short_tokens(monkeypatch):
-    monkeypatch.setattr(server, "run_select_query", lambda q: pytest.fail("should not query"))
+    def fail_if_called(q, query_label=None):
+        pytest.fail("should not query")
+
+    monkeypatch.setattr(server, "run_select_query", fail_if_called)
     assert server._similar_study_identifiers("a_b") == []
 
 

--- a/tests/test_telemetry_user_id.py
+++ b/tests/test_telemetry_user_id.py
@@ -9,6 +9,7 @@ from mcp.types import Implementation
 from cbioportal_mcp.telemetry import (
     TelemetryMiddleware,
     _DogStatsDClient,
+    _emit_db_query_metrics,
     _emit_tool_metrics,
     _extract_mcp_client_info,
     _extract_oauth_identity,
@@ -17,6 +18,7 @@ from cbioportal_mcp.telemetry import (
     _resolve_caller_identity,
     _sanitize_datadog_tag_value,
     dogstatsd_metrics_configured,
+    traced_db_query,
 )
 
 
@@ -279,6 +281,71 @@ def test_emit_tool_metrics_tags_call_latency_and_errors():
             },
         ),
     ]
+
+
+def test_emit_db_query_metrics_tags_call_latency_and_errors():
+    calls = []
+
+    class FakeDogStatsD:
+        def increment(self, metric, tags):
+            calls.append(("increment", metric, tags))
+
+        def distribution(self, metric, value, tags):
+            calls.append(("distribution", metric, value, tags))
+
+    with patch("cbioportal_mcp.telemetry._get_dogstatsd_client", return_value=FakeDogStatsD()):
+        _emit_db_query_metrics(query_label="study_guide.counts", duration_ms=8.1234, success=False)
+
+    assert calls == [
+        ("increment", "db_query.calls", {"query_label": "study_guide.counts", "success": "false"}),
+        (
+            "distribution",
+            "db_query.duration_ms",
+            8.123,
+            {"query_label": "study_guide.counts", "success": "false"},
+        ),
+        ("increment", "db_query.errors", {"query_label": "study_guide.counts", "success": "false"}),
+    ]
+
+
+def test_traced_db_query_emits_success_metrics_and_no_error_tag():
+    calls = []
+
+    class FakeDogStatsD:
+        def increment(self, metric, tags):
+            calls.append(("increment", metric, tags))
+
+        def distribution(self, metric, value, tags):
+            calls.append(("distribution", metric, value, tags))
+
+    with patch("cbioportal_mcp.telemetry._get_dogstatsd_client", return_value=FakeDogStatsD()):
+        with traced_db_query("study_guide.study_info"):
+            pass
+
+    tags = {"query_label": "study_guide.study_info", "success": "true"}
+    assert calls == [
+        ("increment", "db_query.calls", tags),
+        ("distribution", "db_query.duration_ms", calls[1][2], tags),
+    ]
+
+
+def test_traced_db_query_reraises_and_tags_the_failure():
+    calls = []
+
+    class FakeDogStatsD:
+        def increment(self, metric, tags):
+            calls.append(("increment", metric, tags))
+
+        def distribution(self, metric, value, tags):
+            calls.append(("distribution", metric, value, tags))
+
+    with patch("cbioportal_mcp.telemetry._get_dogstatsd_client", return_value=FakeDogStatsD()):
+        with pytest.raises(RuntimeError, match="clickhouse unavailable"):
+            with traced_db_query("study_guide.counts"):
+                raise RuntimeError("clickhouse unavailable")
+
+    error_tags = {"query_label": "study_guide.counts", "success": "false"}
+    assert ("increment", "db_query.errors", error_tags) in calls
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Two independent changes to how this server issues ClickHouse SELECTs, found while investigating why Datadog traces show `run_select_query` as slow:

**1. Tag every SELECT by call site for telemetry.** `run_select_query()` is a single funnel for every SELECT this server runs, so its own latency metric currently averages together a cheap primary-key lookup and an expensive multi-table aggregate — hiding which one actually needs attention. Every call site now passes a `query_label` (e.g. `"study_guide.counts"`, `"clickhouse_run_select_query"`, `"list_studies.query"`), wrapped in a new `db.query/<label>` OTel span and `db_query.*` DogStatsD metric (`telemetry.py`'s `traced_db_query` / `_emit_db_query_metrics`, mirroring the existing `_emit_tool_metrics` pattern from #119). Datadog can now break latency down by call site instead of one aggregate number.

**2. Parallelize `get_study_guide`'s dynamic-generation path.** It fires 7 sequential ClickHouse round trips (study info, then 6 more), and every one of them pays the same fixed per-call connection overhead — `mcp_clickhouse.create_clickhouse_client()` opens a fresh TLS/auth connection per call, with no pooling. Sections 2-7 only depend on the resolved `study_id`, not on each other or on section order, so they're now fired concurrently via a `ThreadPoolExecutor` once `study_id` resolves, and consumed in the original section order — so the guide's rendered output is byte-for-byte unchanged regardless of which query finishes first, but wall-clock cost for that portion drops from roughly six times the per-call connection overhead to roughly one.

These two changes are independent of each other (and independent of #118, the `list_studies` caching PR, now merged) but touch overlapping code (`run_select_query`'s signature, `get_study_guide`), so they're bundled here rather than split further.

## Latency benchmark (real ClickHouse Cloud, measured 2026-09-01)

Live A/B: `get_study_guide()` loaded two ways in the same process — this PR's code, and the pre-PR123 sequential code loaded straight from `upstream/main` — both called against the same live ClickHouse Cloud instance, for the same 4 real studies spanning very different sizes, 3 repeats each:

| Study | Samples | OLD (sequential) | NEW (concurrent) | Saved |
|---|---:|---:|---:|---:|
| `msk_ch_2023` | 42,714 | 1762ms | 970ms | 793ms (45%) |
| `msk_met_2021` | 25,775 | 1095ms | 585ms | 510ms (47%) |
| `mel_mskimpact_2020` | 696 | 1124ms | 570ms | 555ms (49%) |
| `brca_hta9_htan_2022` | 5 | 1056ms | 403ms | 653ms (62%) |
| **Overall mean** | | **1260ms** | **632ms** | **628ms (~50%)** |

Savings didn't scale with study size — the smallest study (5 samples) saved the highest *percentage* (62%), since its total time is dominated by the fixed per-call connection overhead this change collapses, not by query execution. The win is from collapsing 6 sequential connection round trips into one concurrent batch, not from any single query running faster.

The `query_label` tagging change (item 1 above) is telemetry-only and adds no measurable latency by design, so there was nothing to benchmark there.

## Test Plan
- `uv run --with pytest pytest tests/ -q` — 62 passed, including new tests: `traced_db_query` emits success/failure metrics and re-raises (`test_telemetry_user_id.py`), every dynamic-guide query carries a distinct `query_label`, and guide section order stays stable even when queries are deliberately made to finish out of order (`test_study_lookup.py`).
- `uv run ruff check` on all touched files — clean (pre-existing lint debt elsewhere in `server.py` is untouched).
