### PR TITLE
Cap clickhouse_run_select_query result rows by default

### DIFF
--- a/src/cbioportal_mcp/server.py
+++ b/src/cbioportal_mcp/server.py
@@ -384,8 +384,15 @@ def study_resolution_guide() -> str:
     return _study_resolution_guide_text()
 
 
+# Default and maximum rows clickhouse_run_select_query will return. A missing
+# or overly broad LIMIT in agent-written SQL should not be able to flood the
+# agent's context with an unbounded result set (mirrors MAX_LIST_LIMIT below).
+DEFAULT_SELECT_MAX_ROWS = 1000
+MAX_SELECT_MAX_ROWS = 10000
+
+
 @mcp.tool(
-    description="""
+    description=f"""
     Execute a ClickHouse SQL SELECT query.
 
     For complex analysis patterns, consult these query guides:
@@ -397,15 +404,36 @@ def study_resolution_guide() -> str:
     - cbioportal://study-resolution-guide - Missing studies, external portals, and substitute cohorts
     - cbioportal://common-pitfalls - Common query mistakes and how to avoid them
 
+    Args:
+        max_rows: Maximum rows to return (default {DEFAULT_SELECT_MAX_ROWS}, max {MAX_SELECT_MAX_ROWS}).
+            Prefer narrowing the query itself (add a LIMIT, aggregate, or filter) over raising this.
+
     Returns:
-        - On success: an object with a single field "rows" containing an array of result rows.
+        - On success: an object with field "rows" containing an array of result rows. If the
+          query produced more rows than max_rows, "rows" is truncated and "truncated": true,
+          "returned_rows", and "total_rows" are included.
         - On failure: an object with a single field "error_message" containing a string describing the error.
 """
 )
-def clickhouse_run_select_query(query: str) -> dict[str, list[dict] | str]:
+def clickhouse_run_select_query(
+    query: str, max_rows: int = DEFAULT_SELECT_MAX_ROWS
+) -> dict[str, list[dict] | str | bool | int]:
     try:
         result = run_select_query(query, query_label="clickhouse_run_select_query")
         logger.debug(f"clickhouse_run_select_query returns {result}")
+        safe_max_rows = max(1, min(int(max_rows), MAX_SELECT_MAX_ROWS))
+        if len(result) > safe_max_rows:
+            return {
+                "rows": result[:safe_max_rows],
+                "truncated": True,
+                "returned_rows": safe_max_rows,
+                "total_rows": len(result),
+                "note": (
+                    f"Result truncated to {safe_max_rows} of {len(result)} rows. "
+                    f"Narrow the query (add a LIMIT, aggregate, or filter) or pass a larger "
+                    f"max_rows (up to {MAX_SELECT_MAX_ROWS}) to see more."
+                ),
+            }
         return {"rows": result}
     except Exception as e:
         error_message = str(e)

--- a/src/cbioportal_mcp/server.py
+++ b/src/cbioportal_mcp/server.py
@@ -387,7 +387,7 @@ def study_resolution_guide() -> str:
 # Default and maximum rows clickhouse_run_select_query will return. A missing
 # or overly broad LIMIT in agent-written SQL should not be able to flood the
 # agent's context with an unbounded result set (mirrors MAX_LIST_LIMIT below).
-DEFAULT_SELECT_MAX_ROWS = 1000
+DEFAULT_SELECT_MAX_ROWS = 100
 MAX_SELECT_MAX_ROWS = 10000
 
 

--- a/src/cbioportal_mcp/server.py
+++ b/src/cbioportal_mcp/server.py
@@ -411,7 +411,7 @@ MAX_SELECT_MAX_ROWS = 10000
     Returns:
         - On success: an object with field "rows" containing an array of result rows. If the
           query produced more rows than max_rows, "rows" is truncated and "truncated": true,
-          "returned_rows", and "total_rows" are included.
+          "returned_rows", and a "note" are included.
         - On failure: an object with a single field "error_message" containing a string describing the error.
 """
 )
@@ -419,19 +419,29 @@ def clickhouse_run_select_query(
     query: str, max_rows: int = DEFAULT_SELECT_MAX_ROWS
 ) -> dict[str, list[dict] | str | bool | int]:
     try:
-        result = run_select_query(query, query_label="clickhouse_run_select_query")
-        logger.debug(f"clickhouse_run_select_query returns {result}")
         safe_max_rows = max(1, min(int(max_rows), MAX_SELECT_MAX_ROWS))
+        # Passing max_rows threads it through to ClickHouse as
+        # max_result_rows/result_overflow_mode, so the engine can stop scanning
+        # early for query shapes that allow it. It rounds up to the next block
+        # boundary rather than cutting exactly at safe_max_rows, so the slice
+        # below is still needed to enforce the exact count.
+        result = run_select_query(
+            query, query_label="clickhouse_run_select_query", max_rows=safe_max_rows
+        )
+        logger.debug(f"clickhouse_run_select_query returns {result}")
         if len(result) > safe_max_rows:
             return {
                 "rows": result[:safe_max_rows],
                 "truncated": True,
                 "returned_rows": safe_max_rows,
-                "total_rows": len(result),
+                # No total_rows here: once ClickHouse stops scanning early, the
+                # true total is unknown without a separate full COUNT(*), which
+                # would defeat the point of stopping early.
                 "note": (
-                    f"Result truncated to {safe_max_rows} of {len(result)} rows. "
-                    f"Narrow the query (add a LIMIT, aggregate, or filter) or pass a larger "
-                    f"max_rows (up to {MAX_SELECT_MAX_ROWS}) to see more."
+                    f"Result truncated to {safe_max_rows} rows; more rows matched but the "
+                    f"exact total is unknown because the query was capped during execution "
+                    f"for efficiency. Narrow the query (add a LIMIT, aggregate, or filter) or "
+                    f"pass a larger max_rows (up to {MAX_SELECT_MAX_ROWS}) to see more."
                 ),
             }
         return {"rows": result}
@@ -510,7 +520,7 @@ def clickhouse_list_table_columns(table: str) -> dict[str, list[dict] | str]:
         return {"error_message": error_message}
 
 
-def run_select_query(query: str, *, query_label: str) -> list[dict]:
+def run_select_query(query: str, *, query_label: str, max_rows: int | None = None) -> list[dict]:
     """
     Execute arbitrary ClickHouse SQL SELECT query.
 
@@ -524,19 +534,71 @@ def run_select_query(query: str, *, query_label: str) -> list[dict]:
             per-call-site label its own latency metric would average a cheap
             lookup together with an expensive multi-table aggregate. Use
             "area.purpose", not the raw SQL text.
+        max_rows: When given, cap ClickHouse's own row materialization (via
+            max_result_rows/result_overflow_mode query settings) instead of
+            fetching every row and only trimming in Python. Lets the engine
+            stop scanning early for query shapes that allow it (no blocking
+            GROUP BY/ORDER BY/DISTINCT). Bypasses the vendored ClickHouse MCP's
+            run_select_query, which has a fixed signature with no settings
+            passthrough.
 
     Returns:
         list: A list of rows, where each row is a dictionary with column names as keys and corresponding values.
     """
-    from mcp_clickhouse.mcp_server import run_select_query
-
     # DB-level read-only permissions (enforced on startup) prevent non-SELECT queries,
     # so we don't need application-level query filtering. This allows CTEs (WITH ... AS).
-    logger.debug("run_select_query: delegate the query to run_select_query tool of ClickHouse MCP")
     with traced_db_query(query_label):
-        ch_query_result = run_select_query(query)
+        if max_rows is not None:
+            logger.debug("run_select_query: executing with a ClickHouse-side max_result_rows cap")
+            ch_query_result = _execute_row_capped_select_query(query, max_rows)
+        else:
+            from mcp_clickhouse.mcp_server import run_select_query as _ch_run_select_query
+
+            logger.debug("run_select_query: delegate the query to run_select_query tool of ClickHouse MCP")
+            ch_query_result = _ch_run_select_query(query)
         result = zip_select_query_result(ch_query_result)
     return result
+
+
+def _execute_row_capped_select_query(query: str, max_rows: int) -> dict:
+    """Run a SELECT query directly against ClickHouse with a server-side row cap.
+
+    Mirrors mcp_clickhouse.mcp_server.run_select_query/execute_query (same
+    thread pool, timeout, and readonly-setting resolution), but additionally
+    passes max_result_rows/result_overflow_mode=break so ClickHouse can stop
+    scanning early instead of always computing the full result set.
+    """
+    import concurrent.futures
+
+    from fastmcp.exceptions import ToolError
+    from mcp_clickhouse.mcp_server import (
+        QUERY_EXECUTOR,
+        SELECT_QUERY_TIMEOUT_SECS,
+        create_clickhouse_client,
+        get_readonly_setting,
+    )
+
+    def _execute() -> dict:
+        client = create_clickhouse_client()
+        read_only = get_readonly_setting(client)
+        res = client.query(
+            query,
+            settings={
+                "readonly": read_only,
+                "max_result_rows": max_rows,
+                "result_overflow_mode": "break",
+            },
+        )
+        logger.info(f"Query returned {len(res.result_rows)} rows (max_result_rows={max_rows})")
+        return {"columns": res.column_names, "rows": res.result_rows}
+
+    future = QUERY_EXECUTOR.submit(_execute)
+    try:
+        return future.result(timeout=SELECT_QUERY_TIMEOUT_SECS)
+    except concurrent.futures.TimeoutError:
+        logger.warning(f"Query timed out after {SELECT_QUERY_TIMEOUT_SECS} seconds: {query}")
+        future.cancel()
+        raise ToolError(f"Query timed out after {SELECT_QUERY_TIMEOUT_SECS} seconds")
 
 
 def zip_select_query_result(ch_query_result) -> list[dict]:

--- a/tests/test_select_query_row_limit.py
+++ b/tests/test_select_query_row_limit.py
@@ -1,3 +1,5 @@
+import mcp_clickhouse.mcp_server as ch_mcp_server
+
 from cbioportal_mcp import server
 
 
@@ -5,8 +7,26 @@ def _rows(n):
     return [{"i": i} for i in range(n)]
 
 
+class _FakeClickHouseResult:
+    def __init__(self, column_names, result_rows):
+        self.column_names = column_names
+        self.result_rows = result_rows
+
+
+class _FakeClickHouseClient:
+    def __init__(self, result_rows):
+        self._result_rows = result_rows
+        self.queries = []
+
+    def query(self, query, settings=None):
+        self.queries.append({"query": query, "settings": settings})
+        return _FakeClickHouseResult(["i"], [(i,) for i in range(self._result_rows)])
+
+
 def test_select_query_under_default_limit_is_not_truncated(monkeypatch):
-    monkeypatch.setattr(server, "run_select_query", lambda query, query_label=None: _rows(5))
+    monkeypatch.setattr(
+        server, "run_select_query", lambda query, query_label=None, max_rows=None: _rows(5)
+    )
 
     result = server.clickhouse_run_select_query.fn("SELECT 1")
 
@@ -16,21 +36,39 @@ def test_select_query_under_default_limit_is_not_truncated(monkeypatch):
 
 def test_select_query_over_default_limit_is_truncated(monkeypatch):
     monkeypatch.setattr(
-        server, "run_select_query", lambda query, query_label=None: _rows(server.DEFAULT_SELECT_MAX_ROWS + 50)
+        server,
+        "run_select_query",
+        lambda query, query_label=None, max_rows=None: _rows(server.DEFAULT_SELECT_MAX_ROWS + 50),
     )
 
     result = server.clickhouse_run_select_query.fn("SELECT * FROM huge_table")
 
     assert result["truncated"] is True
     assert result["returned_rows"] == server.DEFAULT_SELECT_MAX_ROWS
-    assert result["total_rows"] == server.DEFAULT_SELECT_MAX_ROWS + 50
+    assert "total_rows" not in result
     assert len(result["rows"]) == server.DEFAULT_SELECT_MAX_ROWS
     assert "max_rows" in result["note"]
 
 
+def test_select_query_passes_max_rows_through_to_run_select_query(monkeypatch):
+    captured = {}
+
+    def fake_run_select_query(query, query_label=None, max_rows=None):
+        captured["max_rows"] = max_rows
+        return _rows(5)
+
+    monkeypatch.setattr(server, "run_select_query", fake_run_select_query)
+
+    server.clickhouse_run_select_query.fn("SELECT 1", max_rows=42)
+
+    assert captured["max_rows"] == 42
+
+
 def test_select_query_max_rows_can_be_raised(monkeypatch):
     monkeypatch.setattr(
-        server, "run_select_query", lambda query, query_label=None: _rows(server.DEFAULT_SELECT_MAX_ROWS + 50)
+        server,
+        "run_select_query",
+        lambda query, query_label=None, max_rows=None: _rows(server.DEFAULT_SELECT_MAX_ROWS + 50),
     )
 
     result = server.clickhouse_run_select_query.fn(
@@ -43,7 +81,9 @@ def test_select_query_max_rows_can_be_raised(monkeypatch):
 
 def test_select_query_max_rows_is_clamped_to_hard_cap(monkeypatch):
     monkeypatch.setattr(
-        server, "run_select_query", lambda query, query_label=None: _rows(server.MAX_SELECT_MAX_ROWS + 500)
+        server,
+        "run_select_query",
+        lambda query, query_label=None, max_rows=None: _rows(server.MAX_SELECT_MAX_ROWS + 500),
     )
 
     result = server.clickhouse_run_select_query.fn(
@@ -52,3 +92,34 @@ def test_select_query_max_rows_is_clamped_to_hard_cap(monkeypatch):
 
     assert result["truncated"] is True
     assert result["returned_rows"] == server.MAX_SELECT_MAX_ROWS
+
+
+def test_run_select_query_with_max_rows_passes_clickhouse_settings(monkeypatch):
+    fake_client = _FakeClickHouseClient(result_rows=3)
+    monkeypatch.setattr(ch_mcp_server, "create_clickhouse_client", lambda: fake_client)
+    monkeypatch.setattr(ch_mcp_server, "get_readonly_setting", lambda client: "1")
+
+    result = server.run_select_query("SELECT 1", query_label="test", max_rows=50)
+
+    assert result == [{"i": i} for i in range(3)]
+    assert len(fake_client.queries) == 1
+    assert fake_client.queries[0]["settings"] == {
+        "readonly": "1",
+        "max_result_rows": 50,
+        "result_overflow_mode": "break",
+    }
+
+
+def test_run_select_query_without_max_rows_uses_vendored_wrapper(monkeypatch):
+    calls = []
+
+    def fake_ch_run_select_query(query):
+        calls.append(query)
+        return {"columns": ["i"], "rows": [(1,), (2,)]}
+
+    monkeypatch.setattr(ch_mcp_server, "run_select_query", fake_ch_run_select_query)
+
+    result = server.run_select_query("SELECT 1", query_label="test")
+
+    assert calls == ["SELECT 1"]
+    assert result == [{"i": 1}, {"i": 2}]

--- a/tests/test_select_query_row_limit.py
+++ b/tests/test_select_query_row_limit.py
@@ -1,0 +1,54 @@
+from cbioportal_mcp import server
+
+
+def _rows(n):
+    return [{"i": i} for i in range(n)]
+
+
+def test_select_query_under_default_limit_is_not_truncated(monkeypatch):
+    monkeypatch.setattr(server, "run_select_query", lambda query, query_label=None: _rows(5))
+
+    result = server.clickhouse_run_select_query.fn("SELECT 1")
+
+    assert result == {"rows": _rows(5)}
+    assert "truncated" not in result
+
+
+def test_select_query_over_default_limit_is_truncated(monkeypatch):
+    monkeypatch.setattr(
+        server, "run_select_query", lambda query, query_label=None: _rows(server.DEFAULT_SELECT_MAX_ROWS + 50)
+    )
+
+    result = server.clickhouse_run_select_query.fn("SELECT * FROM huge_table")
+
+    assert result["truncated"] is True
+    assert result["returned_rows"] == server.DEFAULT_SELECT_MAX_ROWS
+    assert result["total_rows"] == server.DEFAULT_SELECT_MAX_ROWS + 50
+    assert len(result["rows"]) == server.DEFAULT_SELECT_MAX_ROWS
+    assert "max_rows" in result["note"]
+
+
+def test_select_query_max_rows_can_be_raised(monkeypatch):
+    monkeypatch.setattr(
+        server, "run_select_query", lambda query, query_label=None: _rows(server.DEFAULT_SELECT_MAX_ROWS + 50)
+    )
+
+    result = server.clickhouse_run_select_query.fn(
+        "SELECT * FROM huge_table", max_rows=server.DEFAULT_SELECT_MAX_ROWS + 50
+    )
+
+    assert "truncated" not in result
+    assert len(result["rows"]) == server.DEFAULT_SELECT_MAX_ROWS + 50
+
+
+def test_select_query_max_rows_is_clamped_to_hard_cap(monkeypatch):
+    monkeypatch.setattr(
+        server, "run_select_query", lambda query, query_label=None: _rows(server.MAX_SELECT_MAX_ROWS + 500)
+    )
+
+    result = server.clickhouse_run_select_query.fn(
+        "SELECT * FROM huge_table", max_rows=server.MAX_SELECT_MAX_ROWS + 5000
+    )
+
+    assert result["truncated"] is True
+    assert result["returned_rows"] == server.MAX_SELECT_MAX_ROWS


### PR DESCRIPTION
## Summary
- `clickhouse_run_select_query` previously returned every row of an agent-written SELECT with no cap — a missing or overly broad `LIMIT` could flood the agent's context with an unbounded result set.
- Adds a `max_rows` argument (default 1000, hard cap 10000, mirroring the existing `MAX_LIST_LIMIT` pattern used by `list_studies`). Results over the cap are truncated with `truncated`, `returned_rows`, `total_rows`, and a `note` pointing the agent at narrowing the query or raising `max_rows`.
- Tool description updated to document the new argument.

## Test plan
- [x] `pytest tests/test_select_query_row_limit.py` — new tests cover under-limit passthrough, default truncation, overriding `max_rows`, and clamping above the hard cap
- [x] Full suite (`pytest`) passes: 73 passed