### PR TITLE
Stop mandating a list_guides() call before every question

### DIFF
--- a/src/cbioportal_mcp/resources/system-prompt.md
+++ b/src/cbioportal_mcp/resources/system-prompt.md
@@ -5,8 +5,7 @@ You are a helpful assistant with access to cBioPortal cancer genomics data throu
 ## Resource Reading Requirements
 
 BEFORE ANSWERING ANY QUESTION, you MUST:
-1. Call `list_guides()` to see available guides
-2. Call `read_guide(uri)` to read the relevant guide(s) for the query type:
+1. Call `read_guide(uri)` directly with the URI below that matches the query type — the mapping is already given here, so there's no need to call `list_guides()` first. Only call `list_guides()` first if the question doesn't fit any of the categories below (e.g. discovering a deployment-specific guide, or a genuinely unfamiliar query type):
    - Mutation frequency questions: read `cbioportal://mutation-frequency-guide`
      - **"Across cancer types" / "by cancer type" / "in different cancers"**: jump to the Cross-Cancer-Type Mutation Frequency section of that guide. There is one canonical recipe (single multi-cancer cohort + per-sample `CANCER_TYPE` from `clinical_data_derived`). Do not invent your own cross-study aggregation.
      - **Mutation-type terminology in the question ("point mutation", "synonymous", "silent", "missense", "truncating", "promoter") OR a request that looks like a typo (e.g. "V600V" — which is the synonymous variant, not a typo for V600E)**: read `cbioportal://common-pitfalls` pitfall #16 BEFORE querying. There is a terminology mapping table and a hard rule against silently rewriting the user's question. Synonymous variants are filtered out of most cBioPortal studies — "0 hits" must be explained, not just reported.
@@ -23,8 +22,8 @@ BEFORE ANSWERING ANY QUESTION, you MUST:
    - Cancer type disambiguation: call `search_oncotree(search_term)`
    - **Enumeration / catalog questions** ("what cancer types are in the database", "what studies do you have", "what guides are available", "show me all X"): use the appropriate list tool DIRECTLY — `list_studies(limit=100)` for studies + cancer types, `list_study_guides()` for study-guide inventory, `list_guides()` for topical guides, `search_oncotree(term)` for OncoTree lookups. Do NOT `clickhouse_list_tables` or write exploratory SELECTs first — one tool call is the whole answer. See `cbioportal://common-pitfalls` pitfall #21.
    - When unsure: read `cbioportal://common-pitfalls`
-3. If the question is about a specific study, call `get_study_guide(study_id)` for study-specific patterns
-4. Follow the patterns from those guides when constructing queries
+2. If the question is about a specific study, call `get_study_guide(study_id)` for study-specific patterns
+3. Follow the patterns from those guides when constructing queries
 
 ## Study Discovery and Cancer Type Resolution
 

--- a/tests/test_skip_mandatory_list_guides.py
+++ b/tests/test_skip_mandatory_list_guides.py
@@ -1,0 +1,33 @@
+from cbioportal_mcp import server
+
+
+def test_system_prompt_no_longer_mandates_list_guides_before_read_guide():
+    prompt = server._load_resource("system-prompt.md")
+
+    assert "Call `read_guide(uri)` directly" in prompt
+    assert "no need to call `list_guides()` first" in prompt
+
+
+def test_system_prompt_still_falls_back_to_list_guides_for_unmapped_questions():
+    prompt = server._load_resource("system-prompt.md")
+
+    assert "Only call `list_guides()` first if the question doesn't fit" in prompt
+
+
+def test_system_prompt_still_routes_every_guide_uri():
+    prompt = server._load_resource("system-prompt.md")
+
+    for uri in [
+        "cbioportal://mutation-frequency-guide",
+        "cbioportal://statistical-tests-guide",
+        "cbioportal://clinical-data-guide",
+        "cbioportal://sample-filtering-guide",
+        "cbioportal://study-resolution-guide",
+        "cbioportal://treatment-guide",
+        "cbioportal://gene-expression-guide",
+        "cbioportal://gene-resolution-guide",
+        "cbioportal://external-resources-guide",
+        "cbioportal://faq-guide",
+        "cbioportal://common-pitfalls",
+    ]:
+        assert uri in prompt


### PR DESCRIPTION
## Summary
- `system-prompt.md`'s "Resource Reading Requirements" section required calling `list_guides()` before every question, then separately spelled out the exact guide URI to read per query type — meaning the model paid for a redundant tool round-trip (a call plus its ~12-entry catalog output) on essentially every turn, since it already had the URI it needed.
- The agent now calls `read_guide(uri)` directly using the URI already mapped in the system prompt. `list_guides()` is now the documented fallback only for questions that don't fit any listed category (deployment-specific guides, or a genuinely unfamiliar query type).
- No guide routing logic changed — every URI mapping in the section is unchanged, only the "call `list_guides()` first, always" requirement was dropped.

## Test plan
- [x] `pytest tests/test_skip_mandatory_list_guides.py` — asserts the mandatory-first-call language is gone, the fallback language is present, and every guide URI mapping still appears in the prompt
- [x] Full suite (`pytest`) passes: 72 passed