### PR TITLE
Read precomputed sample_count in list_studies instead of a live join

### DIFF
--- a/sql/6-add-study-sample-counts.sql
+++ b/sql/6-add-study-sample-counts.sql
@@ -1,0 +1,55 @@
+-- ============================================================================
+-- Precomputed sample_count for cancer_study
+-- ============================================================================
+-- list_studies() (see server.py) used to compute this on every call with a
+-- live COUNT(DISTINCT) across two joins (cancer_study -> patient -> sample).
+-- The MCP server caches that result in-process, but the cache refresh itself
+-- still paid for the join+aggregate every cycle. Since sample/patient data
+-- only changes via this daily clone job, there's no reason to recompute the
+-- count more often than once per clone: precompute it here, once, right
+-- after clone+load, same as the OncoTree denormalization in
+-- 2-add-oncotree-fields.sql.
+--
+-- After this runs, list_studies() reads sample_count directly off
+-- cancer_study with no joins and no aggregation.
+--
+-- ClickHouse mutations don't support correlated subqueries (a subquery
+-- referencing the outer table's row), so the per-study count is staged into
+-- a Join-engine table first and pulled in with joinGet(), which ClickHouse
+-- evaluates per-row instead of correlating. Join(ANY, LEFT, ...) makes
+-- joinGet() return the column default (0) for a study with no patients,
+-- matching the original query's LEFT JOIN semantics.
+-- ============================================================================
+
+ALTER TABLE cancer_study ADD COLUMN IF NOT EXISTS sample_count UInt32 DEFAULT 0;
+
+ALTER TABLE cancer_study MODIFY COLUMN sample_count UInt32
+  COMMENT 'Distinct sample count for this study, precomputed at LLM-prep time from patient/sample. Avoids a live COUNT(DISTINCT) join at query time; only as fresh as the last daily clone.';
+
+DROP TABLE IF EXISTS study_sample_counts_staging;
+
+CREATE TABLE study_sample_counts_staging
+(
+    cancer_study_id UInt32,
+    sample_count UInt32
+)
+ENGINE = Join(ANY, LEFT, cancer_study_id);
+
+INSERT INTO study_sample_counts_staging
+SELECT
+    p.cancer_study_id AS cancer_study_id,
+    COUNT(DISTINCT s.internal_id) AS sample_count
+FROM patient p
+LEFT JOIN sample s ON s.patient_id = p.internal_id
+GROUP BY p.cancer_study_id;
+
+-- mutations_sync = 2 forces this mutation to complete (all replicas) before
+-- the query returns, instead of the default async background execution --
+-- required here since the very next statement drops the staging table this
+-- mutation reads from via joinGet().
+ALTER TABLE cancer_study
+  UPDATE sample_count = joinGet('study_sample_counts_staging', 'sample_count', cancer_study_id)
+  WHERE 1
+  SETTINGS mutations_sync = 2;
+
+DROP TABLE IF EXISTS study_sample_counts_staging;

--- a/sql/6-add-study-sample-counts.sql
+++ b/sql/6-add-study-sample-counts.sql
@@ -14,11 +14,11 @@
 -- cancer_study with no joins and no aggregation.
 --
 -- ClickHouse mutations don't support correlated subqueries (a subquery
--- referencing the outer table's row), so the per-study count is staged into
--- a Join-engine table first and pulled in with joinGet(), which ClickHouse
--- evaluates per-row instead of correlating. Join(ANY, LEFT, ...) makes
--- joinGet() return the column default (0) for a study with no patients,
--- matching the original query's LEFT JOIN semantics.
+-- referencing the outer table's row), so the per-study count is computed
+-- into a Join-engine table first and pulled in with joinGet(), which
+-- ClickHouse evaluates per-row instead of correlating. Join(ANY, LEFT, ...)
+-- makes joinGet() return the column default (0) for a study with no
+-- patients, matching the original query's LEFT JOIN semantics.
 -- ============================================================================
 
 ALTER TABLE cancer_study ADD COLUMN IF NOT EXISTS sample_count UInt32 DEFAULT 0;
@@ -26,16 +26,16 @@ ALTER TABLE cancer_study ADD COLUMN IF NOT EXISTS sample_count UInt32 DEFAULT 0;
 ALTER TABLE cancer_study MODIFY COLUMN sample_count UInt32
   COMMENT 'Distinct sample count for this study, precomputed at LLM-prep time from patient/sample. Avoids a live COUNT(DISTINCT) join at query time; only as fresh as the last daily clone.';
 
-DROP TABLE IF EXISTS study_sample_counts_staging;
+DROP TABLE IF EXISTS study_sample_counts_derived;
 
-CREATE TABLE study_sample_counts_staging
+CREATE TABLE study_sample_counts_derived
 (
     cancer_study_id UInt32,
     sample_count UInt32
 )
 ENGINE = Join(ANY, LEFT, cancer_study_id);
 
-INSERT INTO study_sample_counts_staging
+INSERT INTO study_sample_counts_derived
 SELECT
     p.cancer_study_id AS cancer_study_id,
     COUNT(DISTINCT s.internal_id) AS sample_count
@@ -45,11 +45,11 @@ GROUP BY p.cancer_study_id;
 
 -- mutations_sync = 2 forces this mutation to complete (all replicas) before
 -- the query returns, instead of the default async background execution --
--- required here since the very next statement drops the staging table this
+-- required here since the very next statement drops the derived table this
 -- mutation reads from via joinGet().
 ALTER TABLE cancer_study
-  UPDATE sample_count = joinGet('study_sample_counts_staging', 'sample_count', cancer_study_id)
+  UPDATE sample_count = joinGet('study_sample_counts_derived', 'sample_count', cancer_study_id)
   WHERE 1
   SETTINGS mutations_sync = 2;
 
-DROP TABLE IF EXISTS study_sample_counts_staging;
+DROP TABLE IF EXISTS study_sample_counts_derived;

--- a/sql/README.md
+++ b/sql/README.md
@@ -15,6 +15,7 @@ MCP agent can reason about it.
 | 3 | `3-add-cancer-study-query-preferences.sql` | Creates `cancer_study_query_preferences` table + pattern-detected preferences (currently `pan_cancer_tcga`). |
 | 4 | `4-mutation-frequency-views.sql` | Mutation-frequency parameterized views (`gene_mutation_frequency_by_cancer_type`, `top_mutated_genes_in_cohort`) and the two coverage building-block views (`mutation_panel_gene_coverage`, `mutation_wes_coverage`). Handles the "WES is not in `gene_panel`" trap that produces >100% frequencies. See `cbioportal://mutation-frequency-guide`. |
 | 5 | `5-gene-expression-views.sql` | Gene-expression / copy-number-value / methylation views, backed by `genetic_alteration_derived`. Currently `gene_pair_coexpression(study, gene_a, gene_b, profile_type)` for Spearman correlation between two genes. See `cbioportal://gene-expression-guide`. |
+| 6 | `6-add-study-sample-counts.sql` | Precompute `cancer_study.sample_count` once per clone so `list_studies()` reads it directly instead of a live `COUNT(DISTINCT)` join across `patient`/`sample` on every cache refresh. |
 
 Everything under `sql/` directly is **portable** — works against any cBioPortal deployment. Deployment-specific SQL lives under `sql/portal-specific/<portal-name>/`:
 

--- a/src/cbioportal_mcp/server.py
+++ b/src/cbioportal_mcp/server.py
@@ -996,9 +996,11 @@ def _fetch_and_store_studies() -> tuple[tuple[tuple[str, object], ...], ...]:
     """Query ClickHouse for every study's full detail and store it as the
     cache snapshot. Caller must hold _studies_cache_lock.
 
-    Use sample/patient for counts instead of clinical_data_derived. The latter
-    has many clinical-attribute rows per sample and makes first-connect study
-    discovery slower than it needs to be.
+    sample_count is precomputed onto cancer_study by
+    sql/6-add-study-sample-counts.sql as part of the daily clone pipeline, so
+    this is a plain single-table scan -- no joins, no aggregation. The
+    underlying data only changes via that daily clone, so recomputing the
+    count on every cache refresh (let alone every request) bought nothing.
     """
     global _studies_cache_rows, _studies_cache_fetched_at
     query = """
@@ -1007,12 +1009,9 @@ def _fetch_and_store_studies() -> tuple[tuple[tuple[str, object], ...], ...]:
                     cs.name,
                     cs.description,
                     cs.type_of_cancer_id,
-                    COUNT(DISTINCT s.internal_id) as sample_count
+                    cs.sample_count
                 FROM cancer_study cs
-                LEFT JOIN patient p ON p.cancer_study_id = cs.cancer_study_id
-                LEFT JOIN sample s ON s.patient_id = p.internal_id
-                GROUP BY cs.cancer_study_identifier, cs.name, cs.description, cs.type_of_cancer_id
-                ORDER BY sample_count DESC
+                ORDER BY cs.sample_count DESC
             """
     rows = run_select_query(query, query_label="list_studies.all_studies")
     _studies_cache_rows = tuple(tuple(row.items()) for row in rows)

--- a/tests/test_list_studies_performance.py
+++ b/tests/test_list_studies_performance.py
@@ -29,8 +29,11 @@ def test_list_studies_default_uses_trimmed_sample_count_query(monkeypatch):
     assert rows[0]["cancer_study_identifier"] == "study_alpha"
     assert "description" not in rows[0]
     assert "clinical_data_derived" not in queries[0]
-    assert "LEFT JOIN sample" in queries[0]
-    assert "LEFT JOIN patient" in queries[0]
+    # sample_count is precomputed onto cancer_study by
+    # sql/6-add-study-sample-counts.sql, so the read path is a plain
+    # single-table scan -- no joins, no aggregation.
+    assert "JOIN" not in queries[0]
+    assert "cs.sample_count" in queries[0]
 
 
 def test_list_studies_refetches_after_ttl_expires(monkeypatch):


### PR DESCRIPTION
## Summary

Stacked on #128 — this branch is built on top of it, so the diff shown
here includes #128's commit until that one merges (fork-based repo, so
I can't push a base branch directly onto this org's remote to stack
PRs cleanly). Once #128 merges, rebasing this branch onto `main` will
shrink the diff to just this PR's commit.

Once #128's migration has run in production,
`cancer_study.sample_count` exists and is populated, so
`_fetch_and_store_studies()` no longer needs to join through
`patient`/`sample` and compute `COUNT(DISTINCT)` on every 10-minute
cache refresh — it's now a plain single-table scan:

```sql
SELECT cs.cancer_study_identifier, cs.name, cs.description, cs.type_of_cancer_id, cs.sample_count
FROM cancer_study cs
ORDER BY cs.sample_count DESC
```

`tests/test_list_studies_performance.py` updated to assert the query
has no `JOIN` and reads `cs.sample_count` directly, instead of asserting
the old join shape.

## Why this is a separate PR from #128

Deploy ordering matters here: this query will throw an unknown-column
error against any `cancer_study` that hasn't had #128's migration
applied yet. Splitting them means #128 can merge, bake, and get
confirmed against a real daily clone run before this one goes out —
otherwise a single combined change risks list_studies() breaking in
production if the MCP server image rolls before that day's clone job
has applied the new column.

**This PR should not be merged/deployed until #128 has successfully
run against production at least once.**

## Test plan

- [x] `pytest tests/test_list_studies_performance.py` — 7 passed
- [x] `pytest tests/` (full suite) — 69 passed
- [x] `ruff check` on both changed files — clean
- [ ] Confirm against real ClickHouse after #128 has landed: `cs.sample_count` matches the value the old join query would have produced

https://claude.ai/code/session_017q9PuRDebhx8VW2Q9P9SV5