### PR TITLE
Move OAuth client/token storage to Redis

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,11 @@ dependencies = [
     "opentelemetry-sdk>=1.27.0",
     "opentelemetry-exporter-otlp-proto-http>=1.27.0",
     "ddtrace",
+    # Adds the `redis` extra to fastmcp's own py-key-value-aio pin (which only
+    # requests `disk` and `memory`) so RedisStore is importable for OAuth
+    # client/token storage. Version range mirrors fastmcp>=2.10,<2.14's pin
+    # so both requirements resolve to one shared py-key-value-aio install.
+    "py-key-value-aio[redis]>=0.2.8,<0.4.0",
 ]
 
 [project.optional-dependencies]

--- a/src/cbioportal_mcp/auth.py
+++ b/src/cbioportal_mcp/auth.py
@@ -21,11 +21,54 @@ from __future__ import annotations
 
 import logging
 
+from cryptography.fernet import Fernet
+from fastmcp.server.auth.jwt_issuer import derive_jwt_key
 from fastmcp.server.auth.providers.google import GoogleProvider
+from key_value.aio.protocols import AsyncKeyValue
+from key_value.aio.stores.redis import RedisStore
+from key_value.aio.wrappers.encryption import FernetEncryptionWrapper
 
 from cbioportal_mcp.env import get_mcp_config
 
 logger = logging.getLogger(__name__)
+
+
+def _derive_storage_encryption_key(client_secret: str) -> bytes:
+    """Derive the Fernet key used to encrypt OAuth storage at rest.
+
+    Mirrors, step for step, the derivation `OAuthProxy.__init__` uses to
+    build its own default disk store's encryption key (same two-step HKDF
+    chain, same salts) — see fastmcp's `oauth_proxy` module. Reusing it here
+    means we don't have to pass a `jwt_signing_key` override to
+    `GoogleProvider`: it independently derives the same signing key from
+    `client_secret` on every boot, so this stays in sync without the two
+    being wired together explicitly. Deterministic from `client_secret`
+    alone, so the key is stable across restarts — required, since Redis is
+    exactly the place values now persist across them.
+    """
+    jwt_signing_key = derive_jwt_key(
+        high_entropy_material=client_secret,
+        salt="fastmcp-jwt-signing-key",
+    )
+    return derive_jwt_key(
+        high_entropy_material=jwt_signing_key.decode(),
+        salt="fastmcp-storage-encryption-key",
+    )
+
+
+def _build_client_storage(client_secret: str, redis_url: str) -> AsyncKeyValue:
+    """Encrypted Redis-backed store for OAuth client registrations and tokens.
+
+    Redis survives pod restarts; FastMCP's default local-disk store does
+    not — it lives on the pod's own ephemeral filesystem, so every restart
+    (a new image via Keel, a ConfigMap-triggered reload, ...) silently
+    invalidates every client registration and token, kicking users off with
+    an `invalid_token` 401 until they clear local state and re-register.
+    """
+    return FernetEncryptionWrapper(
+        key_value=RedisStore(url=redis_url, default_collection="cbioportal-mcp-oauth"),
+        fernet=Fernet(key=_derive_storage_encryption_key(client_secret)),
+    )
 
 
 def _build_auth_provider() -> GoogleProvider | None:
@@ -59,10 +102,22 @@ def _build_auth_provider() -> GoogleProvider | None:
         return None
 
     logger.info("✅ Google OAuth enabled for client %s", client_id)
+
+    redis_url = config.redis_url
+    if redis_url:
+        client_storage_kwargs = {"client_storage": _build_client_storage(client_secret, redis_url)}
+    else:
+        client_storage_kwargs = {}
+        logger.warning(
+            "REDIS_URL not set — OAuth client registrations and tokens will "
+            "be stored on local disk, which is lost on every pod restart."
+        )
+
     return GoogleProvider(
         client_id=client_id,
         client_secret=client_secret,
         base_url=base_url,
+        **client_storage_kwargs,
         # Request `openid`, `email`, AND `profile` so `enduser.email`
         # populates on spans. Empirically, FastMCP's GoogleTokenVerifier
         # hits Google's legacy /oauth2/v2/userinfo endpoint which only

--- a/src/cbioportal_mcp/env.py
+++ b/src/cbioportal_mcp/env.py
@@ -144,6 +144,25 @@ class McpConfig:
         value = os.getenv("CBIOPORTAL_MCP_GOOGLE_BASE_URL")
         return value if value else None
 
+    @property
+    def redis_url(self) -> Optional[str]:
+        """Redis connection URL for OAuth client/token storage.
+
+        Example: "redis://:password@host:6379/9". When unset, OAuth client
+        registrations and tokens (see `cbioportal_mcp.auth`) fall back to
+        FastMCP's default local-disk store — fine for local dev, but that
+        disk is the pod's own ephemeral filesystem in Kubernetes, so every
+        pod restart silently invalidates every session. Point this at a
+        database index that isn't already claimed by another cBioPortal
+        Redis consumer (e.g. the HTTP session store or the persistence
+        cache, which uses index 8 in production — see
+        `redis.database`/`spring.data.redis.*` in the cBioPortal webapp).
+        Only takes effect when OAuth itself is enabled (all three
+        CBIOPORTAL_MCP_GOOGLE_* variables set).
+        """
+        value = os.getenv("REDIS_URL")
+        return value if value else None
+
 
 # Global instance placeholders for the singleton pattern
 _MCP_CONFIG_INSTANCE = None

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,12 +1,24 @@
 import os
 from unittest.mock import Mock, patch
 
-from cbioportal_mcp.auth import _build_auth_provider
+from key_value.aio.stores.redis import RedisStore
+from key_value.aio.wrappers.encryption import FernetEncryptionWrapper
+
+from cbioportal_mcp.auth import (
+    _build_auth_provider,
+    _build_client_storage,
+    _derive_storage_encryption_key,
+)
 
 _ALL_GOOGLE_ENV = {
     "CBIOPORTAL_MCP_GOOGLE_CLIENT_ID": "123-abc.apps.googleusercontent.com",
     "CBIOPORTAL_MCP_GOOGLE_CLIENT_SECRET": "fake-secret",
     "CBIOPORTAL_MCP_GOOGLE_BASE_URL": "https://mcp.cbioportal.org",
+}
+
+_ALL_GOOGLE_AND_REDIS_ENV = {
+    **_ALL_GOOGLE_ENV,
+    "REDIS_URL": "redis://localhost:6379/9",
 }
 
 
@@ -56,3 +68,55 @@ def test_builds_google_provider_when_all_three_set():
         required_scopes=["openid", "email", "profile"],
         require_authorization_consent=False,
     )
+
+
+def test_builds_google_provider_without_client_storage_when_redis_url_unset():
+    # No REDIS_URL: falls back to GoogleProvider's own default (disk) store,
+    # so no client_storage kwarg should be passed at all.
+    fake_provider = Mock(name="GoogleProvider instance")
+    with (
+        patch.dict(os.environ, _ALL_GOOGLE_ENV, clear=True),
+        patch(
+            "cbioportal_mcp.auth.GoogleProvider", return_value=fake_provider
+        ) as mock_google_provider,
+    ):
+        provider = _build_auth_provider()
+
+    assert provider is fake_provider
+    _, kwargs = mock_google_provider.call_args
+    assert "client_storage" not in kwargs
+
+
+def test_builds_google_provider_with_redis_client_storage_when_redis_url_set():
+    fake_provider = Mock(name="GoogleProvider instance")
+    with (
+        patch.dict(os.environ, _ALL_GOOGLE_AND_REDIS_ENV, clear=True),
+        patch(
+            "cbioportal_mcp.auth.GoogleProvider", return_value=fake_provider
+        ) as mock_google_provider,
+    ):
+        provider = _build_auth_provider()
+
+    assert provider is fake_provider
+    _, kwargs = mock_google_provider.call_args
+    assert isinstance(kwargs["client_storage"], FernetEncryptionWrapper)
+    assert isinstance(kwargs["client_storage"].key_value, RedisStore)
+
+
+def test_derive_storage_encryption_key_is_deterministic():
+    assert _derive_storage_encryption_key("fake-secret") == _derive_storage_encryption_key(
+        "fake-secret"
+    )
+
+
+def test_derive_storage_encryption_key_differs_per_secret():
+    assert _derive_storage_encryption_key("fake-secret") != _derive_storage_encryption_key(
+        "other-secret"
+    )
+
+
+def test_build_client_storage_wraps_redis_store_with_fernet_encryption():
+    storage = _build_client_storage("fake-secret", "redis://localhost:6379/9")
+
+    assert isinstance(storage, FernetEncryptionWrapper)
+    assert isinstance(storage.key_value, RedisStore)

--- a/uv.lock
+++ b/uv.lock
@@ -34,6 +34,15 @@ wheels = [
 ]
 
 [[package]]
+name = "async-timeout"
+version = "5.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/ae/136395dfbfe00dfc94da3f3e136d0b13f394cba8f4841120e34226265780/async_timeout-5.0.1.tar.gz", hash = "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3", size = 9274, upload-time = "2024-11-06T16:41:39.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/ba/e2081de779ca30d473f21f5b30e0e737c438205440784c7dfc81efc2b029/async_timeout-5.0.1-py3-none-any.whl", hash = "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c", size = 6233, upload-time = "2024-11-06T16:41:37.9Z" },
+]
+
+[[package]]
 name = "attrs"
 version = "25.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -154,6 +163,7 @@ dependencies = [
     { name = "mcp-clickhouse" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-sdk" },
+    { name = "py-key-value-aio", extra = ["redis"] },
 ]
 
 [package.optional-dependencies]
@@ -173,6 +183,7 @@ requires-dist = [
     { name = "mcp-clickhouse", specifier = "==0.1.11" },
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.27.0" },
     { name = "opentelemetry-sdk", specifier = ">=1.27.0" },
+    { name = "py-key-value-aio", extras = ["redis"], specifier = ">=0.2.8,<0.4.0" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "pytest-asyncio", marker = "extra == 'dev'" },
     { name = "ruff", marker = "extra == 'dev'" },
@@ -593,6 +604,7 @@ dependencies = [
     { name = "opentelemetry-api" },
     { name = "wrapt" },
 ]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/e2/ba86ee967e91da871065e89f97327c86fa341a3d41b3b95ef8d108437ae2/ddtrace-4.13.0.tar.gz", hash = "sha256:abb13f0dad32b1f8899e078ed7e05669240ea59700269e2216507954d65afef2", size = 2605466, upload-time = "2026-08-11T16:05:52.662Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/52/97/9d4ec43fa15991f195e62795e1d46fb158cab3df29c370d272889b8f8640/ddtrace-4.13.0-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:ad32f895fddbd6b0095f81a6bd7113582c18f11be6d95c3e1c96a23b8f98f3aa", size = 7419251, upload-time = "2026-08-11T16:03:16.323Z" },
     { url = "https://files.pythonhosted.org/packages/58/d8/1b2ea30f999f135eb866e2d8d31bb36619755f697d8255cdb33bf58f1b3b/ddtrace-4.13.0-cp310-cp310-macosx_14_0_x86_64.whl", hash = "sha256:2d82549afeed8ea5062b09eb2995fbf3541af0115336bf0db6aaf519fc480c31", size = 7747545, upload-time = "2026-08-11T16:03:21.531Z" },
@@ -1364,6 +1376,9 @@ disk = [
 memory = [
     { name = "cachetools" },
 ]
+redis = [
+    { name = "redis" },
+]
 
 [[package]]
 name = "py-key-value-shared"
@@ -1737,6 +1752,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "redis"
+version = "8.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "async-timeout", marker = "python_full_version < '3.11.3'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a8/99/604f0b666d4c616d891cf77ebb9db6bb21601344c051aebf1b72b9ff915f/redis-8.1.0.tar.gz", hash = "sha256:6e1a19beef9225c83efd689c7e6b7da2d5215b1f42cd13b7fc3714d0a09c7b25", size = 5254356, upload-time = "2026-07-30T08:51:00.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/66/9d/c5731f6e3608663d4d3656fd8d3aecee8b509c3082818f5a13eae925baea/redis-8.1.0-py3-none-any.whl", hash = "sha256:a4fe1aac3d3b3cc791d4b3d5931c5a956045dc951ee74d1c913ee3ac4d2ee9fb", size = 560618, upload-time = "2026-07-30T08:50:58.497Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Users were getting kicked off the MCP server with `invalid_token` 401s. Root cause: `GoogleProvider`'s default OAuth client/token storage lives on local disk, which is the pod's own ephemeral filesystem — every pod restart (a new `:latest` image via Keel, a ConfigMap-triggered reload from the daily ClickHouse clone, etc.) silently wipes every registered client and issued token.
- Adds an opt-in `REDIS_URL` env var. When set, OAuth storage (client registrations, refresh tokens, upstream tokens, JTI mappings) is backed by a `RedisStore` wrapped in the same Fernet-encryption-at-rest scheme FastMCP's own default disk store uses, so data is encrypted the same way it is today — just durable across restarts instead of wiped by them.
- When `REDIS_URL` is unset, behavior is unchanged (falls back to FastMCP's default local-disk store) — this stays a safe no-op for local dev and any deployment not yet wired up to Redis.
- No new Redis client library needed: `fastmcp`'s own storage abstraction (`py-key-value-aio`) already ships a `RedisStore`; this just adds the `redis` extra to pull it in.

## Deployment note
This PR only covers the application code. `REDIS_URL` is wired up in [knowledgesystems-k8s-deployment#634](https://github.com/knowledgesystems/knowledgesystems-k8s-deployment/pull/634), which points `cbioagent-clickhouse-mcp-auth` at the cBioPortal webapp's own session-Redis instance (`cbioportal-redis-public-master`, credentials reused from the `cbioportal-public-blue` secret), on **database 1**. Database 0 there is Spring's own HTTP session store; 1-15 are otherwise unclaimed. Deliberately *not* the separate persistence-cache Redis instance (`redis.database=8` in the cBioPortal webapp Deployment) — that one runs with `--redis.clear_on_startup=true`, which would wipe this storage on every webapp rollout and reproduce the exact bug this PR fixes.

## Test plan
- [x] `pytest tests/` — 74 passed (69 existing + 5 new)
- [x] New tests cover: `REDIS_URL` unset → no `client_storage` kwarg passed (unchanged behavior); `REDIS_URL` set → `GoogleProvider` receives a `FernetEncryptionWrapper` wrapping a `RedisStore`; encryption key derivation is deterministic per `client_secret` and differs across secrets (required so previously-encrypted Redis entries stay decryptable across restarts)
- [x] Verified the real storage code path end-to-end against a local Redis: a value written by one process is correctly Fernet-decrypted when read back by an independent process (simulating a pod restart)
- [ ] Manual verification against the production Redis in the deployed environment, after knowledgesystems-k8s-deployment#634 is merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
